### PR TITLE
fix: use turbo for docs build in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build docs
-        run: pnpm --filter funstack-router-docs build
+        run: pnpm turbo run build --filter=funstack-router-docs
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Ensures @funstack/router is built before docs via turbo's dependency graph.