### PR TITLE
feat: implement opt-in static fallback mode for Navigation API unavailability

### DIFF
--- a/packages/router/src/__tests__/adapters.test.ts
+++ b/packages/router/src/__tests__/adapters.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NavigationAPIAdapter } from "../core/NavigationAPIAdapter.js";
+import { StaticAdapter } from "../core/StaticAdapter.js";
+import { createAdapter } from "../core/createAdapter.js";
+import { setupNavigationMock, cleanupNavigationMock } from "./setup.js";
+
+describe("NavigationAPIAdapter", () => {
+  let mockNavigation: ReturnType<typeof setupNavigationMock>;
+
+  beforeEach(() => {
+    mockNavigation = setupNavigationMock("http://localhost/test");
+  });
+
+  afterEach(() => {
+    cleanupNavigationMock();
+  });
+
+  describe("getSnapshot", () => {
+    it("returns LocationEntry with URL, key, and state", () => {
+      const adapter = new NavigationAPIAdapter();
+      const snapshot = adapter.getSnapshot();
+
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.url.href).toBe("http://localhost/test");
+      expect(snapshot!.key).toBe("id-0");
+      expect(snapshot!.state).toBeUndefined();
+    });
+
+    it("returns null when Navigation API is unavailable", () => {
+      cleanupNavigationMock();
+
+      const adapter = new NavigationAPIAdapter();
+      const snapshot = adapter.getSnapshot();
+
+      expect(snapshot).toBeNull();
+    });
+  });
+
+  describe("subscribe", () => {
+    it("subscribes to currententrychange events", () => {
+      const adapter = new NavigationAPIAdapter();
+      const callback = vi.fn();
+
+      const unsubscribe = adapter.subscribe(callback);
+
+      expect(mockNavigation.addEventListener).toHaveBeenCalledWith(
+        "currententrychange",
+        callback,
+      );
+
+      unsubscribe();
+      expect(mockNavigation.removeEventListener).toHaveBeenCalledWith(
+        "currententrychange",
+        callback,
+      );
+    });
+
+    it("returns no-op when Navigation API is unavailable", () => {
+      cleanupNavigationMock();
+
+      const adapter = new NavigationAPIAdapter();
+      const callback = vi.fn();
+
+      const unsubscribe = adapter.subscribe(callback);
+      expect(typeof unsubscribe).toBe("function");
+      unsubscribe(); // Should not throw
+    });
+  });
+
+  describe("navigate", () => {
+    it("calls navigation.navigate with correct options", () => {
+      const adapter = new NavigationAPIAdapter();
+
+      adapter.navigate("/new-path");
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("/new-path", {
+        history: "push",
+        state: undefined,
+      });
+    });
+
+    it("passes replace option correctly", () => {
+      const adapter = new NavigationAPIAdapter();
+
+      adapter.navigate("/new-path", { replace: true });
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("/new-path", {
+        history: "replace",
+        state: undefined,
+      });
+    });
+
+    it("passes state option correctly", () => {
+      const adapter = new NavigationAPIAdapter();
+      const state = { foo: "bar" };
+
+      adapter.navigate("/new-path", { state });
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("/new-path", {
+        history: "push",
+        state,
+      });
+    });
+  });
+});
+
+describe("StaticAdapter", () => {
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    // Clean up any navigation mock
+    cleanupNavigationMock();
+
+    // Mock window.location
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        location: {
+          href: "http://localhost/static-test?query=value#hash",
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", {
+        value: originalWindow,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  describe("getSnapshot", () => {
+    it("returns LocationEntry from window.location", () => {
+      const adapter = new StaticAdapter();
+      const snapshot = adapter.getSnapshot();
+
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.url.href).toBe(
+        "http://localhost/static-test?query=value#hash",
+      );
+      expect(snapshot!.key).toBe("__static__");
+      expect(snapshot!.state).toBeUndefined();
+    });
+
+    it("caches the snapshot", () => {
+      const adapter = new StaticAdapter();
+      const snapshot1 = adapter.getSnapshot();
+      const snapshot2 = adapter.getSnapshot();
+
+      expect(snapshot1).toBe(snapshot2);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("returns no-op function (never fires)", () => {
+      const adapter = new StaticAdapter();
+      const callback = vi.fn();
+
+      const unsubscribe = adapter.subscribe(callback);
+      expect(typeof unsubscribe).toBe("function");
+
+      // Callback should never be called in static mode
+      unsubscribe();
+    });
+  });
+
+  describe("navigate", () => {
+    it("warns when called", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const adapter = new StaticAdapter();
+      adapter.navigate("/new-path");
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "FUNSTACK Router: navigate() called in static fallback mode",
+        ),
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/new-path"),
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("setupInterception", () => {
+    it("returns undefined (no interception in static mode)", () => {
+      const adapter = new StaticAdapter();
+      const result = adapter.setupInterception([]);
+
+      expect(result).toBeUndefined();
+    });
+  });
+});
+
+describe("createAdapter", () => {
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    cleanupNavigationMock();
+    // Restore window to original jsdom window before each test
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", {
+        value: originalWindow,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  afterEach(() => {
+    cleanupNavigationMock();
+  });
+
+  it("returns NavigationAPIAdapter when Navigation API is available", () => {
+    setupNavigationMock("http://localhost/");
+
+    const adapter = createAdapter("none");
+    expect(adapter).toBeInstanceOf(NavigationAPIAdapter);
+  });
+
+  it("returns null when Navigation API unavailable and fallback='none'", () => {
+    // Ensure no navigation mock
+    cleanupNavigationMock();
+
+    const adapter = createAdapter("none");
+    expect(adapter).toBeNull();
+  });
+
+  it("returns StaticAdapter when Navigation API unavailable and fallback='static'", () => {
+    // Ensure no navigation mock but window exists
+    cleanupNavigationMock();
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        location: {
+          href: "http://localhost/",
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    const adapter = createAdapter("static");
+    expect(adapter).toBeInstanceOf(StaticAdapter);
+  });
+
+  it("prefers NavigationAPIAdapter even when fallback='static'", () => {
+    // Restore original window first, then setup navigation mock
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", {
+        value: originalWindow,
+        writable: true,
+        configurable: true,
+      });
+    }
+    setupNavigationMock("http://localhost/");
+
+    const adapter = createAdapter("static");
+    expect(adapter).toBeInstanceOf(NavigationAPIAdapter);
+  });
+});

--- a/packages/router/src/__tests__/fallback.test.tsx
+++ b/packages/router/src/__tests__/fallback.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Router } from "../Router.js";
+import { Outlet } from "../Outlet.js";
+import { useParams } from "../hooks/useParams.js";
+import { useLocation } from "../hooks/useLocation.js";
+import { useNavigate } from "../hooks/useNavigate.js";
+import { cleanupNavigationMock } from "./setup.js";
+import { route, type RouteDefinition } from "../route.js";
+
+/**
+ * Tests for fallback mode functionality.
+ * These tests run WITHOUT the Navigation API to verify static fallback behavior.
+ */
+describe("Router with fallback='static'", () => {
+  beforeEach(() => {
+    // Ensure Navigation API is NOT available
+    cleanupNavigationMock();
+
+    // Mock window.location
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        location: {
+          href: "http://localhost/",
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanupNavigationMock();
+  });
+
+  it("renders matched route when fallback='static'", () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/" },
+      writable: true,
+    });
+
+    const routes: RouteDefinition[] = [
+      { path: "/", component: () => <div>Home Page</div> },
+    ];
+
+    render(<Router routes={routes} fallback="static" />);
+    expect(screen.getByText("Home Page")).toBeInTheDocument();
+  });
+
+  it("renders nothing when fallback='none' and Navigation API unavailable", () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/" },
+      writable: true,
+    });
+
+    const routes: RouteDefinition[] = [
+      { path: "/", component: () => <div>Home Page</div> },
+    ];
+
+    const { container } = render(<Router routes={routes} fallback="none" />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing by default when Navigation API unavailable", () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/" },
+      writable: true,
+    });
+
+    const routes: RouteDefinition[] = [
+      { path: "/", component: () => <div>Home Page</div> },
+    ];
+
+    const { container } = render(<Router routes={routes} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("matches route with path parameters in static mode", () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/users/456" },
+      writable: true,
+    });
+
+    function UserDetail() {
+      const { id } = useParams<{ id: string }>();
+      return <div>User ID: {id}</div>;
+    }
+
+    const routes: RouteDefinition[] = [
+      { path: "/users/:id", component: UserDetail },
+    ];
+
+    render(<Router routes={routes} fallback="static" />);
+    expect(screen.getByText("User ID: 456")).toBeInTheDocument();
+  });
+
+  it("provides location via useLocation in static mode", () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/page?foo=bar#section" },
+      writable: true,
+    });
+
+    function Page() {
+      const location = useLocation();
+      return (
+        <div>
+          <span data-testid="pathname">{location.pathname}</span>
+          <span data-testid="search">{location.search}</span>
+          <span data-testid="hash">{location.hash}</span>
+        </div>
+      );
+    }
+
+    const routes: RouteDefinition[] = [{ path: "/page", component: Page }];
+
+    render(<Router routes={routes} fallback="static" />);
+    expect(screen.getByTestId("pathname").textContent).toBe("/page");
+    expect(screen.getByTestId("search").textContent).toBe("?foo=bar");
+    expect(screen.getByTestId("hash").textContent).toBe("#section");
+  });
+
+  it("renders nested routes with Outlet in static mode", () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/about" },
+      writable: true,
+    });
+
+    function Layout() {
+      return (
+        <div>
+          <header>Header</header>
+          <Outlet />
+        </div>
+      );
+    }
+
+    const routes: RouteDefinition[] = [
+      {
+        path: "/",
+        component: Layout,
+        children: [
+          { path: "", component: () => <div>Home</div> },
+          { path: "about", component: () => <div>About</div> },
+        ],
+      },
+    ];
+
+    render(<Router routes={routes} fallback="static" />);
+    expect(screen.getByText("Header")).toBeInTheDocument();
+    expect(screen.getByText("About")).toBeInTheDocument();
+  });
+
+  it("useNavigate returns function that warns in static mode", () => {
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/" },
+      writable: true,
+    });
+
+    function Home() {
+      const navigate = useNavigate();
+      return <button onClick={() => navigate("/about")}>Go to About</button>;
+    }
+
+    const routes: RouteDefinition[] = [{ path: "/", component: Home }];
+
+    render(<Router routes={routes} fallback="static" />);
+
+    // Click the button
+    screen.getByText("Go to About").click();
+
+    // Should warn
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("static fallback mode"),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it("renders nothing for unmatched routes in static mode", () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/unknown" },
+      writable: true,
+    });
+
+    const routes: RouteDefinition[] = [
+      { path: "/", component: () => <div>Home Page</div> },
+    ];
+
+    const { container } = render(<Router routes={routes} fallback="static" />);
+    expect(container.textContent).toBe("");
+  });
+});
+
+describe("Router with fallback='static' and data loaders", () => {
+  beforeEach(() => {
+    cleanupNavigationMock();
+
+    Object.defineProperty(globalThis, "window", {
+      value: {
+        location: {
+          href: "http://localhost/",
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanupNavigationMock();
+  });
+
+  it("executes loaders in static mode", async () => {
+    Object.defineProperty(window, "location", {
+      value: { href: "http://localhost/data" },
+      writable: true,
+    });
+
+    const loader = vi.fn(() => ({ message: "Loaded data" }));
+
+    function DataPage({ data }: { data: { message: string } }) {
+      return <div>{data.message}</div>;
+    }
+
+    const routes = [
+      route({
+        path: "/data",
+        component: DataPage,
+        loader,
+      }),
+    ];
+
+    render(<Router routes={routes} fallback="static" />);
+
+    expect(loader).toHaveBeenCalled();
+    expect(screen.getByText("Loaded data")).toBeInTheDocument();
+  });
+});

--- a/packages/router/src/__tests__/setup.ts
+++ b/packages/router/src/__tests__/setup.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
-import { resetNavigationState } from "../core/navigation.js";
+import { resetNavigationState } from "../core/NavigationAPIAdapter.js";
+import { resetRouterCache } from "../Router.js";
 
 // Mock Navigation API for testing
 export function createMockNavigation(initialUrl = "http://localhost/") {
@@ -185,12 +186,20 @@ export function createMockNavigation(initialUrl = "http://localhost/") {
 // Setup global navigation mock
 export function setupNavigationMock(initialUrl = "http://localhost/") {
   const mockNav = createMockNavigation(initialUrl);
+  // Set on both globalThis and window for compatibility
   (globalThis as Record<string, unknown>).navigation = mockNav;
+  if (typeof window !== "undefined") {
+    (window as unknown as Record<string, unknown>).navigation = mockNav;
+  }
   return mockNav;
 }
 
 // Cleanup
 export function cleanupNavigationMock() {
   delete (globalThis as Record<string, unknown>).navigation;
+  if (typeof window !== "undefined") {
+    delete (window as unknown as Record<string, unknown>).navigation;
+  }
   resetNavigationState();
+  resetRouterCache();
 }

--- a/packages/router/src/context/RouterContext.ts
+++ b/packages/router/src/context/RouterContext.ts
@@ -1,9 +1,10 @@
 import { createContext } from "react";
 import type { NavigateOptions } from "../types.js";
+import type { LocationEntry } from "../core/RouterAdapter.js";
 
 export type RouterContextValue = {
-  /** Current navigation entry */
-  currentEntry: NavigationHistoryEntry;
+  /** Current location entry */
+  locationEntry: LocationEntry;
   /** Current URL */
   url: URL;
   /** Navigate to a new URL */

--- a/packages/router/src/core/NavigationAPIAdapter.ts
+++ b/packages/router/src/core/NavigationAPIAdapter.ts
@@ -1,0 +1,169 @@
+import type {
+  InternalRouteDefinition,
+  NavigateOptions,
+  OnNavigateCallback,
+} from "../types.js";
+import type { RouterAdapter, LocationEntry } from "./RouterAdapter.js";
+import { matchRoutes } from "./matchRoutes.js";
+import { executeLoaders, createLoaderRequest } from "./loaderCache.js";
+
+/**
+ * Fallback AbortController for data loading initialized outside of a navigation event.
+ * Aborted when the next navigation occurs.
+ *
+ * To save resources, this controller is created only when needed.
+ */
+let idleController: AbortController | null = null;
+
+/**
+ * Get the current abort signal for loader cancellation.
+ */
+export function getIdleAbortSignal(): AbortSignal {
+  idleController ??= new AbortController();
+  return idleController.signal;
+}
+
+/**
+ * Reset navigation state. Used for testing.
+ */
+export function resetNavigationState(): void {
+  idleController?.abort();
+  idleController = null;
+}
+
+/**
+ * Check if Navigation API is available.
+ */
+export function hasNavigation(): boolean {
+  return typeof navigation !== "undefined";
+}
+
+/**
+ * Module-level cache for getSnapshot results.
+ * This ensures consistent caching across adapter instances.
+ */
+let cachedSnapshot: LocationEntry | null = null;
+let lastEntry: NavigationHistoryEntry | null = null;
+
+/**
+ * Reset snapshot cache. Used for testing.
+ */
+export function resetSnapshotCache(): void {
+  cachedSnapshot = null;
+  lastEntry = null;
+}
+
+/**
+ * RouterAdapter implementation using the Navigation API.
+ * This is the primary adapter for browsers that support the Navigation API.
+ */
+export class NavigationAPIAdapter implements RouterAdapter {
+  getSnapshot(): LocationEntry | null {
+    if (!hasNavigation()) {
+      return null;
+    }
+    const entry = navigation.currentEntry;
+    if (!entry?.url) return null;
+
+    // Return cached snapshot if the entry hasn't changed (by object identity)
+    // This is required for useSyncExternalStore to work correctly
+    if (cachedSnapshot && lastEntry === entry) {
+      return cachedSnapshot;
+    }
+
+    lastEntry = entry;
+    cachedSnapshot = {
+      url: new URL(entry.url),
+      key: entry.id,
+      state: entry.getState(),
+    };
+    return cachedSnapshot;
+  }
+
+  subscribe(callback: () => void): () => void {
+    if (!hasNavigation()) {
+      return () => {};
+    }
+    navigation.addEventListener("currententrychange", callback);
+    return () => {
+      navigation.removeEventListener("currententrychange", callback);
+    };
+  }
+
+  navigate(to: string, options?: NavigateOptions): void {
+    if (!hasNavigation()) {
+      return;
+    }
+    navigation.navigate(to, {
+      history: options?.replace ? "replace" : "push",
+      state: options?.state,
+    });
+  }
+
+  setupInterception(
+    routes: InternalRouteDefinition[],
+    onNavigate?: OnNavigateCallback,
+  ): (() => void) | undefined {
+    if (!hasNavigation()) {
+      return undefined;
+    }
+
+    const handleNavigate = (event: NavigateEvent) => {
+      // Only intercept same-origin navigations
+      if (!event.canIntercept || event.hashChange) {
+        return;
+      }
+
+      // Check if the URL matches any of our routes
+      const url = new URL(event.destination.url);
+      const matched = matchRoutes(routes, url.pathname);
+
+      // Call onNavigate callback if provided (regardless of route match)
+      if (onNavigate) {
+        onNavigate(event, matched);
+        if (event.defaultPrevented) {
+          return; // Do not intercept, allow browser default
+        }
+      }
+
+      if (matched) {
+        // Abort initial load's loaders if this is the first navigation
+        if (idleController) {
+          idleController.abort();
+          idleController = null;
+        }
+
+        event.intercept({
+          handler: async () => {
+            const request = createLoaderRequest(url);
+
+            // Note: in response to `currententrychange` event, <Router> should already
+            // have dispatched data loaders and the results should be cached.
+            // Here we run executeLoader to retrieve cached results.
+            const currentEntry = navigation.currentEntry;
+            if (!currentEntry) {
+              throw new Error(
+                "Navigation currentEntry is null during navigation interception",
+              );
+            }
+
+            const results = executeLoaders(
+              matched,
+              currentEntry.id,
+              request,
+              event.signal,
+            );
+
+            // Delay navigation until async loaders complete
+            await Promise.all(results.map((r) => r.data));
+          },
+        });
+      }
+    };
+
+    navigation.addEventListener("navigate", handleNavigate);
+    return () => {
+      navigation.removeEventListener("navigate", handleNavigate);
+    };
+  }
+}

--- a/packages/router/src/core/RouterAdapter.ts
+++ b/packages/router/src/core/RouterAdapter.ts
@@ -1,0 +1,50 @@
+import type {
+  InternalRouteDefinition,
+  NavigateOptions,
+  OnNavigateCallback,
+} from "../types.js";
+
+/**
+ * Represents the current location state.
+ * Abstracts NavigationHistoryEntry for static mode compatibility.
+ */
+export type LocationEntry = {
+  /** Current URL */
+  url: URL;
+  /** Unique key identifying this entry (used for loader caching) */
+  key: string;
+  /** State associated with this entry */
+  state: unknown;
+};
+
+/**
+ * Interface for navigation adapters.
+ * Implementations handle mode-specific navigation behavior.
+ */
+export interface RouterAdapter {
+  /**
+   * Get the current location entry.
+   * Returns null during SSR or if unavailable.
+   */
+  getSnapshot(): LocationEntry | null;
+
+  /**
+   * Subscribe to location changes.
+   * Returns an unsubscribe function.
+   */
+  subscribe(callback: () => void): () => void;
+
+  /**
+   * Perform programmatic navigation.
+   */
+  navigate(to: string, options?: NavigateOptions): void;
+
+  /**
+   * Set up navigation interception for route matching.
+   * Returns a cleanup function, or undefined if not supported.
+   */
+  setupInterception(
+    routes: InternalRouteDefinition[],
+    onNavigate?: OnNavigateCallback,
+  ): (() => void) | undefined;
+}

--- a/packages/router/src/core/StaticAdapter.ts
+++ b/packages/router/src/core/StaticAdapter.ts
@@ -1,0 +1,59 @@
+import type {
+  InternalRouteDefinition,
+  NavigateOptions,
+  OnNavigateCallback,
+} from "../types.js";
+import type { RouterAdapter, LocationEntry } from "./RouterAdapter.js";
+
+/**
+ * RouterAdapter implementation for static fallback mode.
+ * Used when the Navigation API is unavailable and fallback="static" is enabled.
+ *
+ * This adapter:
+ * - Reads the current URL from window.location once
+ * - Does not subscribe to location changes (links cause full page loads)
+ * - Warns when navigate() is called
+ * - Does not intercept navigation events
+ */
+export class StaticAdapter implements RouterAdapter {
+  private cachedSnapshot: LocationEntry | null = null;
+
+  getSnapshot(): LocationEntry | null {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    // Cache the snapshot - it never changes in static mode
+    if (!this.cachedSnapshot) {
+      this.cachedSnapshot = {
+        url: new URL(window.location.href),
+        key: "__static__",
+        state: undefined,
+      };
+    }
+    return this.cachedSnapshot;
+  }
+
+  subscribe(_callback: () => void): () => void {
+    // Static mode never fires location change events
+    return () => {};
+  }
+
+  navigate(to: string, _options?: NavigateOptions): void {
+    console.warn(
+      "FUNSTACK Router: navigate() called in static fallback mode. " +
+        "Navigation API is not available in this browser. " +
+        `Attempted to navigate to: ${to}`,
+    );
+    // Note: We intentionally do NOT navigate via window.location.href
+    // to make the behavior explicit and not mask potential issues
+  }
+
+  setupInterception(
+    _routes: InternalRouteDefinition[],
+    _onNavigate?: OnNavigateCallback,
+  ): (() => void) | undefined {
+    // No interception in static mode - links cause full page loads
+    return undefined;
+  }
+}

--- a/packages/router/src/core/createAdapter.ts
+++ b/packages/router/src/core/createAdapter.ts
@@ -1,0 +1,25 @@
+import type { RouterAdapter } from "./RouterAdapter.js";
+import { NavigationAPIAdapter, hasNavigation } from "./NavigationAPIAdapter.js";
+import { StaticAdapter } from "./StaticAdapter.js";
+import type { FallbackMode } from "../types.js";
+
+/**
+ * Create the appropriate RouterAdapter based on browser capabilities and fallback setting.
+ *
+ * @param fallback - The fallback mode to use when Navigation API is unavailable
+ * @returns A RouterAdapter instance, or null if no adapter is available
+ */
+export function createAdapter(fallback: FallbackMode): RouterAdapter | null {
+  // Try Navigation API first
+  if (hasNavigation()) {
+    return new NavigationAPIAdapter();
+  }
+
+  // Fall back to static mode if enabled
+  if (fallback === "static") {
+    return new StaticAdapter();
+  }
+
+  // No adapter available
+  return null;
+}

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -20,6 +20,9 @@ export type {
   NavigateOptions,
   Location,
   OnNavigateCallback,
+  FallbackMode,
 } from "./types.js";
 
 export type { LoaderArgs, RouteDefinition } from "./route.js";
+
+export type { LocationEntry } from "./core/RouterAdapter.js";

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -76,6 +76,14 @@ export type Location = {
 };
 
 /**
+ * Fallback mode for when Navigation API is unavailable.
+ *
+ * - "none": Default behavior - render nothing when Navigation API is unavailable
+ * - "static": Render matched routes without navigation capabilities (MPA behavior)
+ */
+export type FallbackMode = "none" | "static";
+
+/**
  * Callback invoked before navigation is intercepted.
  * Call `event.preventDefault()` to prevent the router from handling this navigation.
  *


### PR DESCRIPTION
Add RouterAdapter interface and implementations to abstract navigation behavior:
- NavigationAPIAdapter: Uses the Navigation API for full SPA experience
- StaticAdapter: Provides static/read-only behavior when Navigation API unavailable
- createAdapter factory function to select appropriate adapter

Router component changes:
- Add `fallback` prop with "none" (default) and "static" modes
- When fallback="static" and Navigation API unavailable, renders matched routes
  using window.location (MPA behavior, links cause full page loads)
- Add LocationEntry type to abstract NavigationHistoryEntry for compatibility
- Update RouterContext to use LocationEntry instead of NavigationHistoryEntry

This enables applications to display content in browsers without Navigation API
support (Firefox, Safari) while maintaining full SPA functionality in supported
browsers.

Implements the design from docs/FALLBACK_MODE_DESIGN.md