### PR TITLE
feat: implement opt-in static fallback mode for Navigation API unavailable browsers

### DIFF
--- a/packages/router/src/__tests__/fallback.test.tsx
+++ b/packages/router/src/__tests__/fallback.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Router } from "../Router.js";
+import { Outlet } from "../Outlet.js";
+import { useParams } from "../hooks/useParams.js";
+import { useLocation } from "../hooks/useLocation.js";
+import { useNavigate } from "../hooks/useNavigate.js";
+import { route, type RouteDefinition } from "../route.js";
+
+// Helper to set up a static window.location without Navigation API
+function setupStaticLocation(url: string) {
+  // Ensure Navigation API is not available
+  delete (globalThis as Record<string, unknown>).navigation;
+
+  // Set up window.location
+  const urlObj = new URL(url);
+  Object.defineProperty(window, "location", {
+    value: {
+      href: url,
+      pathname: urlObj.pathname,
+      search: urlObj.search,
+      hash: urlObj.hash,
+      origin: urlObj.origin,
+      host: urlObj.host,
+      hostname: urlObj.hostname,
+      port: urlObj.port,
+      protocol: urlObj.protocol,
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe("Fallback Mode", () => {
+  beforeEach(() => {
+    // Ensure Navigation API is not available for fallback tests
+    delete (globalThis as Record<string, unknown>).navigation;
+  });
+
+  afterEach(() => {
+    // Cleanup
+    delete (globalThis as Record<string, unknown>).navigation;
+  });
+
+  describe('fallback="none" (default)', () => {
+    it("renders nothing when Navigation API is unavailable", () => {
+      setupStaticLocation("http://localhost/");
+
+      const routes: RouteDefinition[] = [
+        { path: "/", component: () => <div>Home Page</div> },
+      ];
+
+      const { container } = render(<Router routes={routes} />);
+      expect(container.textContent).toBe("");
+    });
+
+    it("renders nothing with explicit fallback='none'", () => {
+      setupStaticLocation("http://localhost/");
+
+      const routes: RouteDefinition[] = [
+        { path: "/", component: () => <div>Home Page</div> },
+      ];
+
+      const { container } = render(<Router routes={routes} fallback="none" />);
+      expect(container.textContent).toBe("");
+    });
+  });
+
+  describe('fallback="static"', () => {
+    it("renders matched route component when Navigation API is unavailable", () => {
+      setupStaticLocation("http://localhost/");
+
+      const routes: RouteDefinition[] = [
+        { path: "/", component: () => <div>Home Page</div> },
+      ];
+
+      render(<Router routes={routes} fallback="static" />);
+      expect(screen.getByText("Home Page")).toBeInTheDocument();
+    });
+
+    it("renders nested routes with Outlet", () => {
+      setupStaticLocation("http://localhost/about");
+
+      function Layout() {
+        return (
+          <div>
+            <header>Header</header>
+            <Outlet />
+          </div>
+        );
+      }
+
+      const routes: RouteDefinition[] = [
+        {
+          path: "/",
+          component: Layout,
+          children: [
+            { path: "", component: () => <div>Home</div> },
+            { path: "about", component: () => <div>About</div> },
+          ],
+        },
+      ];
+
+      render(<Router routes={routes} fallback="static" />);
+      expect(screen.getByText("Header")).toBeInTheDocument();
+      expect(screen.getByText("About")).toBeInTheDocument();
+    });
+
+    it("provides route params via useParams", () => {
+      setupStaticLocation("http://localhost/users/123");
+
+      function UserDetail() {
+        const { id } = useParams<{ id: string }>();
+        return <div>User ID: {id}</div>;
+      }
+
+      const routes: RouteDefinition[] = [
+        { path: "/users/:id", component: UserDetail },
+      ];
+
+      render(<Router routes={routes} fallback="static" />);
+      expect(screen.getByText("User ID: 123")).toBeInTheDocument();
+    });
+
+    it("provides location via useLocation", () => {
+      setupStaticLocation("http://localhost/page?foo=bar#section");
+
+      function Page() {
+        const location = useLocation();
+        return (
+          <div>
+            <span data-testid="pathname">{location.pathname}</span>
+            <span data-testid="search">{location.search}</span>
+            <span data-testid="hash">{location.hash}</span>
+          </div>
+        );
+      }
+
+      const routes: RouteDefinition[] = [{ path: "/page", component: Page }];
+
+      render(<Router routes={routes} fallback="static" />);
+      expect(screen.getByTestId("pathname").textContent).toBe("/page");
+      expect(screen.getByTestId("search").textContent).toBe("?foo=bar");
+      expect(screen.getByTestId("hash").textContent).toBe("#section");
+    });
+
+    it("renders nothing when no route matches", () => {
+      setupStaticLocation("http://localhost/unknown");
+
+      const routes: RouteDefinition[] = [
+        { path: "/", component: () => <div>Home Page</div> },
+      ];
+
+      const { container } = render(
+        <Router routes={routes} fallback="static" />,
+      );
+      expect(container.textContent).toBe("");
+    });
+
+    it("useNavigate returns a function that warns on call", () => {
+      setupStaticLocation("http://localhost/");
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      function NavigateTester() {
+        const navigate = useNavigate();
+        return <button onClick={() => navigate("/about")}>Navigate</button>;
+      }
+
+      const routes: RouteDefinition[] = [
+        { path: "/", component: NavigateTester },
+      ];
+
+      render(<Router routes={routes} fallback="static" />);
+
+      // Click the button to trigger navigate
+      screen.getByText("Navigate").click();
+
+      // Should have logged a warning
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("static fallback mode"),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("does not call onNavigate callback in static mode", () => {
+      setupStaticLocation("http://localhost/");
+      const onNavigate = vi.fn();
+
+      const routes: RouteDefinition[] = [
+        { path: "/", component: () => <div>Home</div> },
+      ];
+
+      render(
+        <Router routes={routes} fallback="static" onNavigate={onNavigate} />,
+      );
+
+      // onNavigate should never be called in static mode
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("data loaders in static mode", () => {
+    it("executes sync loader and passes data to component", () => {
+      setupStaticLocation("http://localhost/");
+
+      function MessageComponent({ data }: { data: { message: string } }) {
+        return <div>{data.message}</div>;
+      }
+
+      const routes = [
+        route({
+          path: "/",
+          loader: () => ({ message: "Hello from loader" }),
+          component: MessageComponent,
+        }),
+      ];
+
+      render(<Router routes={routes} fallback="static" />);
+      expect(screen.getByText("Hello from loader")).toBeInTheDocument();
+    });
+
+    it("executes loader with correct params", () => {
+      setupStaticLocation("http://localhost/users/456");
+      const loader = vi.fn(() => ({ name: "Test User" }));
+
+      function UserComponent({ data }: { data: { name: string } }) {
+        return <div>{data.name}</div>;
+      }
+
+      const routes = [
+        route({
+          path: "/users/:id",
+          loader,
+          component: UserComponent,
+        }),
+      ];
+
+      render(<Router routes={routes} fallback="static" />);
+
+      expect(loader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { id: "456" },
+        }),
+      );
+      expect(screen.getByText("Test User")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/router/src/__tests__/setup.ts
+++ b/packages/router/src/__tests__/setup.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { resetNavigationState } from "../core/navigation.js";
+import { resetNavigationState } from "../core/NavigationAPIAdapter.js";
 
 // Mock Navigation API for testing
 export function createMockNavigation(initialUrl = "http://localhost/") {

--- a/packages/router/src/context/RouterContext.ts
+++ b/packages/router/src/context/RouterContext.ts
@@ -1,9 +1,10 @@
 import { createContext } from "react";
 import type { NavigateOptions } from "../types.js";
+import type { LocationEntry } from "../core/RouterAdapter.js";
 
 export type RouterContextValue = {
-  /** Current navigation entry */
-  currentEntry: NavigationHistoryEntry;
+  /** Current location entry */
+  locationEntry: LocationEntry;
   /** Current URL */
   url: URL;
   /** Navigate to a new URL */

--- a/packages/router/src/core/NavigationAPIAdapter.ts
+++ b/packages/router/src/core/NavigationAPIAdapter.ts
@@ -1,0 +1,164 @@
+import type { RouterAdapter, LocationEntry } from "./RouterAdapter.js";
+import type {
+  InternalRouteDefinition,
+  NavigateOptions,
+  OnNavigateCallback,
+} from "../types.js";
+import { matchRoutes } from "./matchRoutes.js";
+import { executeLoaders, createLoaderRequest } from "./loaderCache.js";
+
+/**
+ * Fallback AbortController for data loading initialized outside of a navigation event.
+ * Aborted when the next navigation occurs.
+ *
+ * To save resources, this controller is created only when needed.
+ */
+let idleController: AbortController | null = null;
+
+/**
+ * Reset navigation state. Used for testing.
+ */
+export function resetNavigationState(): void {
+  idleController?.abort();
+  idleController = null;
+}
+
+/**
+ * Check if Navigation API is available.
+ */
+function hasNavigation(): boolean {
+  return typeof navigation !== "undefined";
+}
+
+/**
+ * Adapter that uses the Navigation API for full SPA functionality.
+ */
+export class NavigationAPIAdapter implements RouterAdapter {
+  // Cache the snapshot to ensure referential stability for useSyncExternalStore
+  private cachedSnapshot: LocationEntry | null = null;
+  private cachedEntryId: string | null = null;
+
+  getSnapshot(): LocationEntry | null {
+    if (!hasNavigation()) {
+      return null;
+    }
+    const entry = navigation.currentEntry;
+    if (!entry?.url) {
+      return null;
+    }
+
+    // Return cached snapshot if entry hasn't changed
+    if (this.cachedEntryId === entry.id && this.cachedSnapshot) {
+      return this.cachedSnapshot;
+    }
+
+    // Create new snapshot and cache it
+    this.cachedEntryId = entry.id;
+    this.cachedSnapshot = {
+      url: new URL(entry.url),
+      key: entry.id,
+      state: entry.getState(),
+    };
+    return this.cachedSnapshot;
+  }
+
+  getServerSnapshot(): LocationEntry | null {
+    return null;
+  }
+
+  subscribe(callback: () => void): () => void {
+    if (!hasNavigation()) {
+      return () => {};
+    }
+    navigation.addEventListener("currententrychange", callback);
+    return () => {
+      if (hasNavigation()) {
+        navigation.removeEventListener("currententrychange", callback);
+      }
+    };
+  }
+
+  navigate(to: string, options?: NavigateOptions): void {
+    if (!hasNavigation()) {
+      return;
+    }
+    navigation.navigate(to, {
+      history: options?.replace ? "replace" : "push",
+      state: options?.state,
+    });
+  }
+
+  setupInterception(
+    routes: InternalRouteDefinition[],
+    onNavigate?: OnNavigateCallback,
+  ): (() => void) | undefined {
+    if (!hasNavigation()) {
+      return undefined;
+    }
+
+    const handleNavigate = (event: NavigateEvent) => {
+      // Only intercept same-origin navigations
+      if (!event.canIntercept || event.hashChange) {
+        return;
+      }
+
+      // Check if the URL matches any of our routes
+      const url = new URL(event.destination.url);
+      const matched = matchRoutes(routes, url.pathname);
+
+      // Call onNavigate callback if provided (regardless of route match)
+      if (onNavigate) {
+        onNavigate(event, matched);
+        if (event.defaultPrevented) {
+          return; // Do not intercept, allow browser default
+        }
+      }
+
+      if (matched) {
+        // Abort initial load's loaders if this is the first navigation
+        if (idleController) {
+          idleController.abort();
+          idleController = null;
+        }
+
+        event.intercept({
+          handler: async () => {
+            const request = createLoaderRequest(url);
+
+            // Note: in response to `currententrychange` event, <Router> should already
+            // have dispatched data loaders and the results should be cached.
+            // Here we run executeLoader to retrieve cached results.
+            const currentEntry = navigation.currentEntry;
+            if (!currentEntry) {
+              throw new Error(
+                "Navigation currentEntry is null during navigation interception",
+              );
+            }
+
+            const results = executeLoaders(
+              matched,
+              currentEntry.id,
+              request,
+              event.signal,
+            );
+
+            // Delay navigation until async loaders complete
+            await Promise.all(results.map((r) => r.data));
+          },
+        });
+      }
+    };
+
+    navigation.addEventListener("navigate", handleNavigate);
+    return () => {
+      if (hasNavigation()) {
+        navigation.removeEventListener("navigate", handleNavigate);
+      }
+    };
+  }
+
+  getIdleAbortSignal(): AbortSignal {
+    idleController ??= new AbortController();
+    return idleController.signal;
+  }
+}

--- a/packages/router/src/core/RouterAdapter.ts
+++ b/packages/router/src/core/RouterAdapter.ts
@@ -1,0 +1,62 @@
+import type {
+  InternalRouteDefinition,
+  NavigateOptions,
+  OnNavigateCallback,
+} from "../types.js";
+
+/**
+ * Represents the current location state.
+ * Abstracts NavigationHistoryEntry for static mode compatibility.
+ */
+export type LocationEntry = {
+  /** The current URL */
+  url: URL;
+  /** Unique key for this entry (used for loader caching) */
+  key: string;
+  /** State associated with this entry */
+  state: unknown;
+};
+
+/**
+ * Interface for navigation adapters.
+ * Implementations handle mode-specific navigation behavior.
+ */
+export interface RouterAdapter {
+  /**
+   * Get the current location entry.
+   * Returns null during SSR or if unavailable.
+   */
+  getSnapshot(): LocationEntry | null;
+
+  /**
+   * Get the server snapshot for SSR.
+   * Returns null as location is not available on server.
+   */
+  getServerSnapshot(): LocationEntry | null;
+
+  /**
+   * Subscribe to location changes.
+   * Returns an unsubscribe function.
+   */
+  subscribe(callback: () => void): () => void;
+
+  /**
+   * Perform programmatic navigation.
+   */
+  navigate(to: string, options?: NavigateOptions): void;
+
+  /**
+   * Set up navigation interception for route matching.
+   * Returns a cleanup function, or undefined if not supported.
+   */
+  setupInterception(
+    routes: InternalRouteDefinition[],
+    onNavigate?: OnNavigateCallback,
+  ): (() => void) | undefined;
+
+  /**
+   * Get an abort signal for loader cancellation.
+   * The signal is aborted when a new navigation starts.
+   */
+  getIdleAbortSignal(): AbortSignal;
+}

--- a/packages/router/src/core/StaticAdapter.ts
+++ b/packages/router/src/core/StaticAdapter.ts
@@ -1,0 +1,65 @@
+import type { RouterAdapter, LocationEntry } from "./RouterAdapter.js";
+import type {
+  InternalRouteDefinition,
+  NavigateOptions,
+  OnNavigateCallback,
+} from "../types.js";
+
+/**
+ * Static adapter for fallback mode when Navigation API is unavailable.
+ * Provides read-only location access with no SPA navigation capabilities.
+ * Links will cause full page loads (MPA behavior).
+ */
+export class StaticAdapter implements RouterAdapter {
+  private cachedSnapshot: LocationEntry | null = null;
+  private idleController: AbortController | null = null;
+
+  getSnapshot(): LocationEntry | null {
+    if (typeof window === "undefined") {
+      return null;
+    }
+
+    // Cache the snapshot - it never changes in static mode
+    if (!this.cachedSnapshot) {
+      this.cachedSnapshot = {
+        url: new URL(window.location.href),
+        key: "__static__",
+        state: undefined,
+      };
+    }
+    return this.cachedSnapshot;
+  }
+
+  getServerSnapshot(): LocationEntry | null {
+    return null;
+  }
+
+  subscribe(_callback: () => void): () => void {
+    // Static mode never fires location change events
+    return () => {};
+  }
+
+  navigate(to: string, _options?: NavigateOptions): void {
+    console.warn(
+      "FUNSTACK Router: navigate() called in static fallback mode. " +
+        "Navigation API is not available in this browser. " +
+        "Links will cause full page loads.",
+    );
+    // Note: We intentionally do NOT do window.location.href = to
+    // as that would mask bugs where developers expect SPA behavior.
+    // If needed in the future, we could add a "static-reload" mode.
+  }
+
+  setupInterception(
+    _routes: InternalRouteDefinition[],
+    _onNavigate?: OnNavigateCallback,
+  ): (() => void) | undefined {
+    // No interception in static mode - links cause full page loads
+    return undefined;
+  }
+
+  getIdleAbortSignal(): AbortSignal {
+    this.idleController ??= new AbortController();
+    return this.idleController.signal;
+  }
+}

--- a/packages/router/src/core/createAdapter.ts
+++ b/packages/router/src/core/createAdapter.ts
@@ -1,0 +1,33 @@
+import type { RouterAdapter } from "./RouterAdapter.js";
+import { NavigationAPIAdapter } from "./NavigationAPIAdapter.js";
+import { StaticAdapter } from "./StaticAdapter.js";
+import type { FallbackMode } from "../types.js";
+
+/**
+ * Check if Navigation API is available.
+ */
+function hasNavigation(): boolean {
+  return typeof window !== "undefined" && "navigation" in window;
+}
+
+/**
+ * Create the appropriate router adapter based on browser capabilities
+ * and the specified fallback mode.
+ *
+ * @param fallback - The fallback mode to use when Navigation API is unavailable
+ * @returns A RouterAdapter instance, or null if no adapter is available
+ */
+export function createAdapter(fallback: FallbackMode): RouterAdapter | null {
+  // Try Navigation API first
+  if (hasNavigation()) {
+    return new NavigationAPIAdapter();
+  }
+
+  // Fall back to static mode if enabled
+  if (fallback === "static") {
+    return new StaticAdapter();
+  }
+
+  // No adapter available (fallback="none" or default)
+  return null;
+}

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -20,6 +20,9 @@ export type {
   NavigateOptions,
   Location,
   OnNavigateCallback,
+  FallbackMode,
 } from "./types.js";
+
+export type { LocationEntry } from "./core/RouterAdapter.js";
 
 export type { LoaderArgs, RouteDefinition } from "./route.js";

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -86,3 +86,13 @@ export type OnNavigateCallback = (
   event: NavigateEvent,
   matched: readonly MatchedRoute[] | null,
 ) => void;
+
+/**
+ * Fallback mode when Navigation API is unavailable.
+ *
+ * - `"none"` (default): Render nothing when Navigation API is unavailable
+ * - `"static"`: Render matched routes without navigation capabilities (MPA behavior)
+ */
+export type FallbackMode =
+  | "none" // Default: render nothing when Navigation API unavailable
+  | "static"; // Render matched routes without navigation capabilities


### PR DESCRIPTION
This adds a `fallback` prop to the Router component that enables static rendering
when the Navigation API is not available (e.g., Firefox, Safari).

Key changes:
- Add RouterAdapter interface for abstracting navigation behavior
- Implement NavigationAPIAdapter for full SPA functionality
- Implement StaticAdapter for static fallback mode (MPA behavior)
- Add createAdapter factory function for adapter selection
- Add FallbackMode type ('none' | 'static')
- Refactor Router to use adapter pattern
- Update RouterContext to use LocationEntry abstraction
- Add comprehensive tests for fallback mode

Usage:
  <Router routes={routes} fallback="static" />

In static mode:
- Routes are matched and rendered based on current URL
- Data loaders execute normally
- Links cause full page loads (no SPA navigation)
- useNavigate() logs a warning when called
- onNavigate callback is never called

Closes the implementation outlined in docs/FALLBACK_MODE_DESIGN.md