### PR TITLE
docs: add Firefox 147+ to Navigation API browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,9 @@ The Navigation API is supported in:
 
 - Chrome 102+
 - Edge 102+
+- Firefox 147+
 - Safari 26.2+
 - Opera 88+
-
-Firefox does not yet support the Navigation API. For Firefox, consider using a polyfill.
 
 ## License
 

--- a/docs/FALLBACK_MODE_DESIGN.md
+++ b/docs/FALLBACK_MODE_DESIGN.md
@@ -27,11 +27,11 @@ Navigation API is supported in:
 
 - Chrome 102+ (March 2022)
 - Edge 102+ (June 2022)
+- Firefox 147+ (July 2025)
 - Opera 88+ (June 2022)
 
 **Not supported in**:
 
-- Firefox (under consideration)
 - Safari (no public signal)
 
 ## Design Goals

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -306,10 +306,9 @@ The Navigation API is supported in:
 
 - Chrome 102+
 - Edge 102+
+- Firefox 147+
 - Safari 26.2+
 - Opera 88+
-
-Firefox does not yet support the Navigation API.
 
 For unsupported browsers, use the `fallback="static"` option on the Router component, which renders matched routes without SPA navigation capabilities (links cause full page loads).
 

--- a/packages/docs/src/pages/GettingStartedPage.tsx
+++ b/packages/docs/src/pages/GettingStartedPage.tsx
@@ -26,9 +26,8 @@ yarn add @funstack/router`}</code>
           >
             Navigation API
           </a>{" "}
-          which is supported in Chrome 102+, Edge 102+, Safari 26.2+, and Opera
-          88+. Firefox does not yet support the Navigation API; for Firefox,
-          consider using a polyfill.
+          which is supported in Chrome 102+, Edge 102+, Firefox 147+, Safari
+          26.2+, and Opera 88+.
         </p>
       </section>
 


### PR DESCRIPTION
Firefox 147 now supports the Navigation API. Updated browser support
documentation across README, architecture docs, fallback mode design,
and the getting started page.