### PR TITLE
fix(docs): correct GitHub link URL

### DIFF
--- a/packages/docs/src/components/Layout.tsx
+++ b/packages/docs/src/components/Layout.tsx
@@ -37,7 +37,7 @@ export function Layout() {
             ))}
           </nav>
           <a
-            href="https://github.com/user/funstack-router"
+            href="https://github.com/uhyo/funstack-router"
             className="github-link"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
Change from placeholder 'user' to actual repo owner 'uhyo'