### PR TITLE
fix: SSR loader cache isolation and form-submission action race

### DIFF
--- a/packages/docs/src/pages/LearnActionsPage.tsx
+++ b/packages/docs/src/pages/LearnActionsPage.tsx
@@ -184,6 +184,12 @@ loader: async ({ params, actionResult, signal }) => {
           This lets your UI display feedback from the action (e.g. success messages or validation
           errors) alongside the refreshed data.
         </p>
+        <p>
+          While the action (and the subsequent loader re-execution) is in flight, the Router keeps
+          the current page rendered and reports the navigation as pending via <code>isPending</code>{" "}
+          / <code>useIsPending()</code>. The new page renders only with the post-action loader data,
+          so components never observe data loaded before the action ran.
+        </p>
       </section>
 
       <section>

--- a/packages/router/src/Router/index.tsx
+++ b/packages/router/src/Router/index.tsx
@@ -195,9 +195,13 @@ export function Router({
               }
             }
             await wait;
-            // Re-read the snapshot: a superseding navigation may have
-            // resolved the wait, in which case this renders the newest entry.
-            setLocationEntry(adapter.getSnapshot());
+            // Updates after the first await are not part of the transition
+            // unless wrapped in a nested startTransition call.
+            startTransition(() => {
+              // Re-read the snapshot: a superseding navigation may have
+              // resolved the wait, in which case this renders the newest entry.
+              setLocationEntry(adapter.getSnapshot());
+            });
           });
           return;
         }

--- a/packages/router/src/Router/index.tsx
+++ b/packages/router/src/Router/index.tsx
@@ -179,22 +179,25 @@ export function Router({
           // keeping the old UI and isPending up) until the adapter has
           // dispatched loaders with the action result.
           const { wait, navigationType } = change;
+          // The entry is already committed, so the snapshot has the final
+          // URL. Read it now so transition types can be added synchronously
+          // inside the transition — addTransitionType is not supported
+          // after an await.
+          const committedSnapshot = adapter.getSnapshot();
           startTransition(async () => {
-            await wait;
-            const newSnapshot = adapter.getSnapshot();
-            if (newSnapshot) {
-              // Note: addTransitionType after an await requires async
-              // transition support; on builds without it this is already a
-              // silent no-op (see core/addTransitionType.ts).
+            if (committedSnapshot) {
               const types = getTransitionTypes({
-                url: newSnapshot.url,
+                url: committedSnapshot.url,
                 navigationType,
               });
               for (const type of types) {
                 addTransitionType(type);
               }
             }
-            setLocationEntry(newSnapshot);
+            await wait;
+            // Re-read the snapshot: a superseding navigation may have
+            // resolved the wait, in which case this renders the newest entry.
+            setLocationEntry(adapter.getSnapshot());
           });
           return;
         }

--- a/packages/router/src/Router/index.tsx
+++ b/packages/router/src/Router/index.tsx
@@ -172,6 +172,32 @@ export function Router({
   useEffect(() => {
     return adapter.subscribe((change) => {
       if (change.kind === "navigation") {
+        if (change.wait) {
+          // Intercepted form submission: the entry has committed but the
+          // action hasn't run yet. Rendering now would execute loaders
+          // without the action result, so wait (inside an async transition,
+          // keeping the old UI and isPending up) until the adapter has
+          // dispatched loaders with the action result.
+          const { wait, navigationType } = change;
+          startTransition(async () => {
+            await wait;
+            const newSnapshot = adapter.getSnapshot();
+            if (newSnapshot) {
+              // Note: addTransitionType after an await requires async
+              // transition support; on builds without it this is already a
+              // silent no-op (see core/addTransitionType.ts).
+              const types = getTransitionTypes({
+                url: newSnapshot.url,
+                navigationType,
+              });
+              for (const type of types) {
+                addTransitionType(type);
+              }
+            }
+            setLocationEntry(newSnapshot);
+          });
+          return;
+        }
         const newSnapshot = adapter.getSnapshot();
         startTransition(() => {
           if (newSnapshot) {

--- a/packages/router/src/Router/index.tsx
+++ b/packages/router/src/Router/index.tsx
@@ -241,14 +241,27 @@ export function Router({
   const runLoaders = locationEntry !== null || (!!ssr?.runLoaders && urlObject !== null);
 
   /**
-   * Key of location. This is used as the cache key for loader data saved in navigation entry.
+   * Key of location provided by the adapter, or null when no location entry
+   * is available (SSR, or Navigation API unavailable with fallback="none").
    */
-  const locationKey =
+  const realLocationKey =
     locationEntry?.key ??
     (isServerSnapshot(locationEntryInternal)
       ? locationEntryInternal.actualLocationEntry?.key
       : null) ??
-    "ssr";
+    null;
+  /**
+   * Key of location. This is used as the cache key for loader data saved in navigation entry.
+   */
+  const locationKey = realLocationKey ?? "ssr";
+
+  // Loader cache for renders without a location entry. The module-level cache
+  // is keyed by navigation entry and cleaned up via dispose events; without an
+  // entry, every render in the same process would share the literal "ssr" slot,
+  // serving one request's loader data to all subsequent SSR/SSG renders. An
+  // instance-scoped cache keeps such results memoized for this Router's
+  // lifetime only, and is garbage-collected with it.
+  const [instanceLoaderCache] = useState(() => new Map<string, unknown>());
 
   // Match routes and execute loaders
   const matchedRoutesWithData = useMemo(() => {
@@ -274,8 +287,17 @@ export function Router({
     const entryKey = locationKey;
     const request = createLoaderRequest(urlObject);
     const signal = adapter.getIdleAbortSignal();
-    return executeLoaders(matched, entryKey, request, signal);
-  }, [routes, adapter, urlObject, runLoaders, locationKey]);
+    return executeLoaders(
+      matched,
+      entryKey,
+      request,
+      signal,
+      undefined,
+      // Without a real location entry, scope loader results to this Router
+      // instance instead of the shared module-level cache.
+      realLocationKey === null ? instanceLoaderCache : undefined,
+    );
+  }, [routes, adapter, urlObject, runLoaders, locationKey, realLocationKey, instanceLoaderCache]);
 
   const locationState = locationEntry?.state;
   const locationInfo = locationEntry?.info;

--- a/packages/router/src/__tests__/actionRevalidation.test.tsx
+++ b/packages/router/src/__tests__/actionRevalidation.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, act } from "@testing-library/react";
+import { Suspense, use } from "react";
 import { Router } from "../Router/index.js";
 import { route, type LoaderArgs } from "../route.js";
 import { setupNavigationMock, cleanupNavigationMock } from "./setup.js";
@@ -109,6 +110,65 @@ describe("action revalidation through <Router>", () => {
     expect(screen.getByTestId("out")).toHaveTextContent("loaded(actionResult=OK)");
     expect(loader).toHaveBeenCalledTimes(1);
     expect(loaderArgs).toEqual(["OK"]);
+  });
+
+  it("applies the post-wait update as a transition (async loader keeps old UI, no Suspense fallback)", async () => {
+    let resolveLoader!: (value: string) => void;
+    const action = vi.fn(async () => "OK");
+    const loader = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveLoader = resolve;
+        }),
+    );
+    function FormPage({ data }: { data: Promise<string> }) {
+      const value = use(data);
+      return <div data-testid="out">{value}</div>;
+    }
+    const routes = [
+      route({ path: "/", component: () => <div data-testid="out">home</div> }),
+      route({ path: "/form", action, loader, component: FormPage }),
+    ];
+    render(
+      <Suspense fallback={<div data-testid="out">fallback</div>}>
+        <Router routes={routes} />
+      </Suspense>,
+    );
+
+    const formData = new FormData();
+    const { event, proceed } = mockNavigation.__simulateNavigationWithEvent(
+      "http://localhost/form",
+      { formData },
+    );
+    const handler = (event.intercept as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .handler as () => Promise<void>;
+
+    await act(async () => {
+      proceed();
+    });
+    // Action resolves immediately, but the loader's promise stays pending, so
+    // the handler (and the navigation) are still in flight.
+    const handlerDone = handler();
+    await act(async () => {
+      // Let the adapter's deferred resolve and the Router's post-wait update
+      // render. The route component suspends on the pending loader promise;
+      // since the update is a transition, the old page must stay up instead
+      // of the Suspense fallback appearing.
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId("out")).toHaveTextContent("home");
+
+    await act(async () => {
+      resolveLoader("loaded-async");
+      await handlerDone;
+    });
+    await act(async () => {
+      mockNavigation
+        .__getListeners("navigatesuccess")
+        ?.forEach((listener) => listener(new Event("navigatesuccess")));
+    });
+    expect(screen.getByTestId("out")).toHaveTextContent("loaded-async");
+    expect(loader).toHaveBeenCalledTimes(1);
   });
 
   it("does not leave the UI hanging when the action throws", async () => {

--- a/packages/router/src/__tests__/actionRevalidation.test.tsx
+++ b/packages/router/src/__tests__/actionRevalidation.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { Router } from "../Router/index.js";
+import { route, type LoaderArgs } from "../route.js";
+import { setupNavigationMock, cleanupNavigationMock } from "./setup.js";
+import { clearLoaderCache } from "../core/loaderCache.js";
+
+// Integration tests for the interplay between <Router> rendering and the
+// intercept handler during form submissions. The browser commits the entry
+// (currententrychange) BEFORE the intercept handler runs the action, so the
+// Router must not execute loaders (or render the new page) until the action
+// has completed and loaders have re-executed with its result.
+describe("action revalidation through <Router>", () => {
+  let mockNavigation: ReturnType<typeof setupNavigationMock>;
+
+  beforeEach(() => {
+    mockNavigation = setupNavigationMock("http://localhost/");
+    clearLoaderCache();
+  });
+
+  afterEach(() => {
+    cleanupNavigationMock();
+    vi.restoreAllMocks();
+  });
+
+  function setup(action: () => unknown) {
+    const loaderArgs: unknown[] = [];
+    const loader = vi.fn(({ actionResult }: LoaderArgs<Record<string, never>, unknown>) => {
+      loaderArgs.push(actionResult);
+      return `loaded(actionResult=${String(actionResult)})`;
+    });
+    const routes = [
+      route({ path: "/", component: () => <div data-testid="out">home</div> }),
+      route({
+        path: "/form",
+        action,
+        loader,
+        component: ({ data }: { data: string }) => <div data-testid="out">{data}</div>,
+      }),
+    ];
+    render(<Router routes={routes} />);
+
+    // Simulate a POST form submission the way a browser sequences it:
+    // navigate event (intercept registered) → commit/currententrychange →
+    // intercept handler → navigatesuccess.
+    const formData = new FormData();
+    formData.set("x", "1");
+    const { event, proceed } = mockNavigation.__simulateNavigationWithEvent(
+      "http://localhost/form",
+      { formData },
+    );
+    const interceptMock = event.intercept as ReturnType<typeof vi.fn>;
+    expect(interceptMock).toHaveBeenCalledTimes(1);
+    const handler = interceptMock.mock.calls[0][0].handler as () => Promise<void>;
+    const fireNavigateSuccess = () => {
+      mockNavigation
+        .__getListeners("navigatesuccess")
+        ?.forEach((listener) => listener(new Event("navigatesuccess")));
+    };
+    return { loader, loaderArgs, proceed, handler, fireNavigateSuccess };
+  }
+
+  it("renders post-action loader data after a slow action, executing the loader once", async () => {
+    let resolveAction!: (value: string) => void;
+    const action = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveAction = resolve;
+        }),
+    );
+    const { loader, loaderArgs, proceed, handler, fireNavigateSuccess } = setup(action);
+
+    // Commit the entry while the action is still pending: the old page must
+    // stay up and the loader must not run yet.
+    await act(async () => {
+      proceed();
+    });
+    expect(screen.getByTestId("out")).toHaveTextContent("home");
+    expect(loader).not.toHaveBeenCalled();
+
+    const handlerDone = handler();
+    expect(loader).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveAction("OK");
+      await handlerDone;
+    });
+    await act(async () => {
+      fireNavigateSuccess();
+    });
+
+    expect(screen.getByTestId("out")).toHaveTextContent("loaded(actionResult=OK)");
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loaderArgs).toEqual(["OK"]);
+  });
+
+  it("renders post-action loader data for an immediately-resolving action", async () => {
+    const action = vi.fn(async () => "OK");
+    const { loader, loaderArgs, proceed, handler, fireNavigateSuccess } = setup(action);
+
+    await act(async () => {
+      proceed();
+      await handler();
+    });
+    await act(async () => {
+      fireNavigateSuccess();
+    });
+
+    expect(screen.getByTestId("out")).toHaveTextContent("loaded(actionResult=OK)");
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loaderArgs).toEqual(["OK"]);
+  });
+
+  it("does not leave the UI hanging when the action throws", async () => {
+    const action = vi.fn(async () => {
+      throw new Error("action failed");
+    });
+    const { proceed, handler, fireNavigateSuccess } = setup(action);
+
+    await act(async () => {
+      proceed();
+    });
+    await act(async () => {
+      await expect(handler()).rejects.toThrow("action failed");
+    });
+    // In a real browser, navigateerror (not navigatesuccess) would fire here;
+    // the point is that the pending deferred was released and the router
+    // rendered the committed entry instead of waiting forever.
+    await act(async () => {
+      fireNavigateSuccess();
+    });
+
+    // The entry committed, the action failed before loaders ran, so the
+    // loader executes at render time without an action result.
+    expect(screen.getByTestId("out")).toHaveTextContent("loaded(actionResult=undefined)");
+  });
+});

--- a/packages/router/src/__tests__/ssrLoaderCache.test.tsx
+++ b/packages/router/src/__tests__/ssrLoaderCache.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Router } from "../Router/index.js";
+import { route } from "../route.js";
+import { clearLoaderCache } from "../core/loaderCache.js";
+
+// No navigation mock is set up in this file: the Router falls back to
+// NullAdapter, and the `ssr` prop drives route matching — the same code path
+// as server-side rendering. Multiple <Router> mounts in one process simulate
+// multiple SSR requests (or SSG pages) rendered by the same server process.
+describe("SSR loader cache isolation", () => {
+  beforeEach(() => {
+    clearLoaderCache();
+  });
+
+  function makeRoutes(loaderA: () => string, loaderB: () => string) {
+    return [
+      route({
+        path: "/a",
+        loader: loaderA,
+        component: ({ data }: { data: string }) => <div data-testid="out">{data}</div>,
+      }),
+      route({
+        path: "/b",
+        loader: loaderB,
+        component: ({ data }: { data: string }) => <div data-testid="out">{data}</div>,
+      }),
+    ];
+  }
+
+  it("does not leak loader data across Router instances rendering different paths", () => {
+    const loaderA = vi.fn(() => "data-for-A");
+    const loaderB = vi.fn(() => "data-for-B");
+
+    const first = render(
+      <Router routes={makeRoutes(loaderA, loaderB)} ssr={{ path: "/a", runLoaders: true }} />,
+    );
+    expect(screen.getByTestId("out")).toHaveTextContent("data-for-A");
+    first.unmount();
+
+    const second = render(
+      <Router routes={makeRoutes(loaderA, loaderB)} ssr={{ path: "/b", runLoaders: true }} />,
+    );
+    expect(screen.getByTestId("out")).toHaveTextContent("data-for-B");
+    expect(loaderB).toHaveBeenCalledTimes(1);
+    second.unmount();
+  });
+
+  it("re-executes loaders for each Router instance rendering the same path", () => {
+    // Each SSR render is a separate request: loader results must not be
+    // shared between them even for the same URL.
+    const loader = vi.fn(() => "data");
+    const routes = [
+      route({
+        path: "/a",
+        loader,
+        component: ({ data }: { data: string }) => <div data-testid="out">{data}</div>,
+      }),
+    ];
+
+    const first = render(<Router routes={routes} ssr={{ path: "/a", runLoaders: true }} />);
+    first.unmount();
+    const second = render(<Router routes={routes} ssr={{ path: "/a", runLoaders: true }} />);
+    second.unmount();
+
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("still memoizes loader results within a single Router instance", () => {
+    const loader = vi.fn(() => "data");
+    const mkRoutes = () => [
+      route({
+        path: "/a",
+        loader,
+        component: ({ data }: { data: string }) => <div data-testid="out">{data}</div>,
+      }),
+    ];
+
+    const view = render(<Router routes={mkRoutes()} ssr={{ path: "/a", runLoaders: true }} />);
+    // New routes array identity forces the matching memo to recompute;
+    // the instance cache must still prevent a second loader execution.
+    view.rerender(<Router routes={mkRoutes()} ssr={{ path: "/a", runLoaders: true }} />);
+
+    expect(screen.getByTestId("out")).toHaveTextContent("data");
+    expect(loader).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+});

--- a/packages/router/src/core/NavigationAPIAdapter.ts
+++ b/packages/router/src/core/NavigationAPIAdapter.ts
@@ -338,11 +338,7 @@ export class NavigationAPIAdapter implements RouterAdapter {
       // data. Must be set before intercept() so it is in place when
       // currententrychange fires.
       if (isFormSubmission) {
-        let resolve!: () => void;
-        const promise = new Promise<void>((r) => {
-          resolve = r;
-        });
-        this.#pendingFormNavigation = { promise, resolve };
+        this.#pendingFormNavigation = Promise.withResolvers<void>();
       }
       const pendingFormNavigation = this.#pendingFormNavigation;
 

--- a/packages/router/src/core/NavigationAPIAdapter.ts
+++ b/packages/router/src/core/NavigationAPIAdapter.ts
@@ -58,6 +58,16 @@ export class NavigationAPIAdapter implements RouterAdapter {
   // the `currententrychange` event — and thus its navigationType — may be
   // missing. Falls back to "push" if no intercept has been observed yet.
   #lastInterceptedNavigationType: NavigationType = "push";
+  // Deferred that is pending while an intercepted form submission's action
+  // is running. The commit (and thus currententrychange) happens before the
+  // action, so subscribers must wait for this before rendering — otherwise
+  // loaders would execute with `actionResult: undefined` and the render
+  // would capture pre-action data. Resolved (never rejected) once loaders
+  // have been dispatched with the action result.
+  #pendingFormNavigation: {
+    promise: Promise<void>;
+    resolve: () => void;
+  } | null = null;
 
   getSnapshot(): LocationEntry | null {
     const entry = navigation.currentEntry;
@@ -109,7 +119,11 @@ export class NavigationAPIAdapter implements RouterAdapter {
         if (navigationType === null) {
           callback({ kind: "state" });
         } else {
-          callback({ kind: "navigation", navigationType });
+          callback({
+            kind: "navigation",
+            navigationType,
+            wait: this.#pendingFormNavigation?.promise,
+          });
         }
       },
       { signal: controller.signal },
@@ -223,6 +237,12 @@ export class NavigationAPIAdapter implements RouterAdapter {
         return;
       }
 
+      // A new navigation supersedes any in-flight form submission. Release
+      // subscribers that may be awaiting the stale deferred so they never
+      // hang; the superseded handler's own finally is a no-op afterwards.
+      this.#pendingFormNavigation?.resolve();
+      this.#pendingFormNavigation = null;
+
       // Capture ephemeral info from the navigate event
       // This info is only available during this navigation and resets on the next one
       this.#currentNavigationInfo = event.info;
@@ -311,58 +331,87 @@ export class NavigationAPIAdapter implements RouterAdapter {
         idleController = null;
       }
 
+      // For form submissions, the entry commits (and currententrychange
+      // fires) before the action runs. Create a deferred that subscribers
+      // wait on before rendering, so loaders are not executed eagerly with
+      // `actionResult: undefined` and the render never captures pre-action
+      // data. Must be set before intercept() so it is in place when
+      // currententrychange fires.
+      if (isFormSubmission) {
+        let resolve!: () => void;
+        const promise = new Promise<void>((r) => {
+          resolve = r;
+        });
+        this.#pendingFormNavigation = { promise, resolve };
+      }
+      const pendingFormNavigation = this.#pendingFormNavigation;
+
       event.intercept({
         handler: async () => {
-          const currentEntry = navigation.currentEntry;
-          if (!currentEntry) {
-            throw new Error("Navigation currentEntry is null during navigation interception");
-          }
-
-          // Don't invalidate the cache here: getSnapshot's cache check
-          // already returns the same reference when the resolved URL is
-          // unchanged (normal mode), avoiding an extra render when
-          // navigatesuccess fires after currententrychange.
-          this.#committedDestination = {
-            entryId: currentEntry.id,
-            href: event.destination.url,
-          };
-
-          const composite = `${currentEntry.id}|${event.destination.url}`;
-          const effectiveKey = this.#effectiveKey(composite);
-
-          let actionResult: unknown = undefined;
-
-          if (isFormSubmission) {
-            // Find the deepest matched route with an action
-            const actionRoute = findActionRoute(matched);
-            if (actionRoute) {
-              const actionRequest = createActionRequest(url, event.formData!);
-              actionResult = await actionRoute.route.action!({
-                params: actionRoute.params,
-                request: actionRequest,
-                signal: event.signal,
-              });
+          try {
+            const currentEntry = navigation.currentEntry;
+            if (!currentEntry) {
+              throw new Error("Navigation currentEntry is null during navigation interception");
             }
-            // Revalidate loaders after action — clear cache so loaders re-execute
-            clearLoaderCacheForEntry(composite);
+
+            // Don't invalidate the cache here: getSnapshot's cache check
+            // already returns the same reference when the resolved URL is
+            // unchanged (normal mode), avoiding an extra render when
+            // navigatesuccess fires after currententrychange.
+            this.#committedDestination = {
+              entryId: currentEntry.id,
+              href: event.destination.url,
+            };
+
+            const composite = `${currentEntry.id}|${event.destination.url}`;
+            const effectiveKey = this.#effectiveKey(composite);
+
+            let actionResult: unknown = undefined;
+
+            if (isFormSubmission) {
+              // Find the deepest matched route with an action
+              const actionRoute = findActionRoute(matched);
+              if (actionRoute) {
+                const actionRequest = createActionRequest(url, event.formData!);
+                actionResult = await actionRoute.route.action!({
+                  params: actionRoute.params,
+                  request: actionRequest,
+                  signal: event.signal,
+                });
+              }
+              // Revalidate loaders after action — clear cache so loaders re-execute
+              clearLoaderCacheForEntry(composite);
+            }
+
+            const request = createLoaderRequest(url);
+
+            // Note: in response to `currententrychange` event, <Router> should already
+            // have dispatched data loaders and the results should be cached —
+            // except for form submissions, where subscribers wait on the pending
+            // deferred and the loaders execute here, with actionResult.
+            const results = executeLoaders(
+              matched,
+              effectiveKey,
+              request,
+              event.signal,
+              actionResult,
+            );
+
+            // Loaders are dispatched and cached; subscribers can render now.
+            // Async loader data settles under React's transition, so the old
+            // UI stays up until it is ready.
+            pendingFormNavigation?.resolve();
+
+            // Delay navigation until async loaders complete
+            await Promise.all(results.map((r) => r.data));
+          } finally {
+            // Also release subscribers when the action or a loader throws,
+            // so a waiting render never hangs.
+            pendingFormNavigation?.resolve();
+            if (this.#pendingFormNavigation === pendingFormNavigation) {
+              this.#pendingFormNavigation = null;
+            }
           }
-
-          const request = createLoaderRequest(url);
-
-          // Note: in response to `currententrychange` event, <Router> should already
-          // have dispatched data loaders and the results should be cached.
-          // Here we run executeLoader to retrieve cached results.
-          // For form submissions, cache was cleared above so loaders re-execute with actionResult.
-          const results = executeLoaders(
-            matched,
-            effectiveKey,
-            request,
-            event.signal,
-            actionResult,
-          );
-
-          // Delay navigation until async loaders complete
-          await Promise.all(results.map((r) => r.data));
         },
       });
     };

--- a/packages/router/src/core/RouterAdapter.ts
+++ b/packages/router/src/core/RouterAdapter.ts
@@ -17,9 +17,16 @@ export type EntryChangeType = "navigation" | "state";
  * - `kind: "navigation"` carries the underlying navigation type
  *   (push, replace, reload, traverse).
  * - `kind: "state"` is a state-only update via `updateCurrentEntry()`.
+ *
+ * When `wait` is present, the subscriber must wait for it to settle before
+ * reading the new snapshot and re-rendering. Used for intercepted form
+ * submissions: the entry commits before the action runs, so rendering
+ * eagerly would execute loaders without the action result. The promise
+ * settles (it never rejects) once loaders have been dispatched with the
+ * action result.
  */
 export type EntryChange =
-  | { kind: "navigation"; navigationType: NavigationType }
+  | { kind: "navigation"; navigationType: NavigationType; wait?: Promise<void> }
   | { kind: "state" };
 
 /**

--- a/packages/router/src/core/loaderCache.ts
+++ b/packages/router/src/core/loaderCache.ts
@@ -22,6 +22,7 @@ const loaderCache = new Map<string, unknown>();
  * If the result is not cached, executes the loader and caches the result.
  */
 function getOrCreateLoaderResult(
+  cache: Map<string, unknown>,
   entryId: string,
   matchIndex: number,
   route: InternalRouteDefinition,
@@ -33,18 +34,18 @@ function getOrCreateLoaderResult(
 
   const cacheKey = `${entryId}:${matchIndex}`;
 
-  if (!loaderCache.has(cacheKey)) {
+  if (!cache.has(cacheKey)) {
     try {
-      loaderCache.set(cacheKey, route.loader(args));
+      cache.set(cacheKey, route.loader(args));
     } catch (error) {
       // Wrap synchronous loader errors so they don't crash the Router
       // during useMemo. RouteRenderer will unwrap and re-throw during
       // rendering, where Error Boundaries can catch them.
-      loaderCache.set(cacheKey, new LoaderError(error));
+      cache.set(cacheKey, new LoaderError(error));
     }
   }
 
-  return loaderCache.get(cacheKey);
+  return cache.get(cacheKey);
 }
 
 /**
@@ -69,6 +70,11 @@ export function createActionRequest(url: URL, formData: FormData): Request {
 /**
  * Execute loaders for matched routes and return routes with data.
  * Results are cached by navigation entry id to prevent duplicate execution.
+ *
+ * By default, results are stored in the module-level cache, which is keyed
+ * by navigation entry and cleaned up via dispose events. Callers that have
+ * no navigation entry (SSR, Navigation API unavailable) must pass their own
+ * `cache` so results are scoped to that render instead of shared globally.
  */
 export function executeLoaders(
   matchedRoutes: MatchedRoute[],
@@ -76,6 +82,7 @@ export function executeLoaders(
   request: Request,
   signal: AbortSignal,
   actionResult?: unknown,
+  cache: Map<string, unknown> = loaderCache,
 ): MatchedRouteWithData[] {
   return matchedRoutes.map((match, index) => {
     const { route, params } = match;
@@ -85,7 +92,7 @@ export function executeLoaders(
       signal,
       actionResult,
     };
-    const data = getOrCreateLoaderResult(entryId, index, route, args);
+    const data = getOrCreateLoaderResult(cache, entryId, index, route, args);
 
     return { ...match, data };
   });

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "lib": ["ES2022", "ES2024.Promise", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "ES2024.Promise", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
Fixes the two high-severity bugs found in the library audit (the remaining findings were filed as issues #204–#219).

## 1. SSR/SSG loader cache leaked data across renders

Without a navigation entry, loader results were cached under the literal `"ssr"` key in the module-level cache, so a long-running SSR server (or a multi-page SSG build) served the **first** render's loader data to every subsequent render — rendering `/a` then `/b` in one process showed `/a`'s data on the `/b` page, and `/b`'s loader never ran.

**Fix:** `executeLoaders` gained an optional `cache` parameter. When the Router has no real location entry (SSR, or Navigation API unavailable), it passes a per-instance cache (created with `useState`, garbage-collected with the instance) instead of the shared module-level map. Each SSR request/SSG page now executes loaders fresh, while results remain memoized within a single render lifecycle. Client-side behavior with real entry keys is unchanged.

## 2. Form submissions rendered pre-action loader data

For intercepted form submissions, the entry commits (and `currententrychange` fires) before the intercept handler runs the action. The Router's transition render executed loaders eagerly with `actionResult: undefined`, and because the handler's post-action re-execution produced no new snapshot reference, the revalidated data was never rendered: the UI kept the pre-action results, and loader side effects ran twice. (Only visible with actions slower than a microtask, which is why existing adapter-level tests didn't catch it.)

**Fix:** the adapter creates a pending deferred when it intercepts a form submission and attaches it to the entry-change notification as `wait`; the Router waits on it inside an async transition (old UI and `isPending` stay up) before reading the snapshot and rendering. Loaders execute exactly once, with the action result, and the committed render always shows post-action data. The deferred is released on action errors and superseding navigations so a waiting render can never hang.

## Testing

- 6 new regression tests: `ssrLoaderCache.test.tsx` (cross-instance isolation, per-request re-execution, within-instance memoization) and `actionRevalidation.test.tsx` (slow action, immediate action, action error — driven through `<Router>` with the browser's real event ordering: navigate → commit → handler → navigatesuccess).
- Full suite: 281 tests + type tests pass; lint, format, and the router package build are clean.
- Note: `funstack-router-docs` SSG build fails in my container on every commit including `master` (Node 22 lacks global `URLPattern`) — unrelated to this change.

Also includes a small docs addition to the Form Actions page describing the (now-guaranteed) pending behavior during submissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012B1oYTQh1Q7hhBgirpGiek