### PR TITLE
fix: preserve loader cache across same-URL replace navigations

### DIFF
--- a/packages/docs/src/pages/ApiTypesPage.tsx
+++ b/packages/docs/src/pages/ApiTypesPage.tsx
@@ -50,7 +50,9 @@ type Props = {
             <code>setState</code> - Async method that returns a Promise. Uses replace navigation
             internally, ensuring the state update goes through the full navigation cycle. Because it
             performs a navigation, it is wrapped in a React transition and may set{" "}
-            <code>isPending</code> to <code>true</code>.
+            <code>isPending</code> to <code>true</code>. Loaders do <strong>not</strong> re-execute:
+            since the URL is unchanged, cached loader results are carried over to the new navigation
+            entry.
           </li>
           <li>
             <code>setStateSync</code> - Synchronous method that updates state immediately using{" "}

--- a/packages/docs/src/pages/ApiUtilitiesPage.tsx
+++ b/packages/docs/src/pages/ApiUtilitiesPage.tsx
@@ -229,6 +229,11 @@ const productRoute = routeState<{ filter: string }>()({
           <li>State persists when navigating back/forward in history</li>
           <li>Each history entry has its own independent state</li>
           <li>State must be serializable (no functions, Symbols, or DOM nodes)</li>
+          <li>
+            State updates never re-execute loaders &mdash; loaders cannot observe navigation state,
+            and cached loader results are preserved across <code>setState</code>&rsquo;s same-URL
+            replace navigation
+          </li>
         </ul>
         <h4>Internal Storage</h4>
         <p>

--- a/packages/docs/src/pages/LearnLoadersPage.tsx
+++ b/packages/docs/src/pages/LearnLoadersPage.tsx
@@ -101,8 +101,17 @@ function UserDetail({ data }: { data: Promise<User> }) {
         <p>
           A <strong>push</strong> navigation (the default when clicking a link or calling{" "}
           <code>navigate()</code>) creates a new navigation entry. Since the entry is new, loaders
-          always execute. A <strong>replace</strong> navigation behaves the same way &mdash; it
-          creates a new entry that replaces the current one, so loaders execute fresh.
+          always execute. A <strong>replace</strong> navigation to a <strong>different</strong> URL
+          behaves the same way &mdash; it creates a new entry that replaces the current one, so
+          loaders execute fresh.
+        </p>
+        <p>
+          A replace navigation to the <strong>same</strong> URL &mdash; most commonly the async{" "}
+          <code>setState</code> / <code>resetState</code> props, which persist navigation state via
+          a same-URL replace &mdash; carries the cached loader results over to the new entry, so
+          loaders do <strong>not</strong> re-execute. Loaders cannot observe navigation state (it is
+          not part of their arguments), so saving UI state never requires a refetch. When you do
+          want fresh data on the current URL, use <code>navigation.reload()</code>.
         </p>
 
         <h4>Traverse (Back / Forward)</h4>
@@ -222,9 +231,16 @@ function UserDetail({ data }: { data: Promise<User> }) {
           </thead>
           <tbody>
             <tr>
-              <td>Push / Replace</td>
+              <td>Push / Replace (different URL)</td>
               <td>Yes</td>
               <td>New navigation entry, no cache</td>
+            </tr>
+            <tr>
+              <td>
+                Same-URL replace (async <code>setState</code> / <code>resetState</code>)
+              </td>
+              <td>No</td>
+              <td>Cached results are carried over to the new entry</td>
             </tr>
             <tr>
               <td>Traverse (Back / Forward)</td>

--- a/packages/router/src/__tests__/state.test.tsx
+++ b/packages/router/src/__tests__/state.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { Router } from "../Router/index.js";
 import { Outlet } from "../Outlet.js";
@@ -636,6 +636,182 @@ describe("Navigation State Management", () => {
 
       expect(screen.queryByText("apple")).not.toBeInTheDocument();
       expect(screen.getByText("banana")).toBeInTheDocument();
+    });
+  });
+
+  describe("loader cache across async state updates (#204)", () => {
+    it("does not re-execute the loader when setState replaces the current entry", async () => {
+      type PageState = { count: number };
+      const loader = vi.fn(() => ({ message: "loaded" }));
+
+      function Page({
+        data,
+        state,
+        setState,
+      }: RouteComponentProps<Record<string, never>, PageState> & {
+        data: { message: string };
+      }) {
+        return (
+          <div>
+            <span>Data: {data.message}</span>
+            <span>Count: {state?.count ?? 0}</span>
+            <button onClick={() => void setState({ count: 1 })}>Save</button>
+          </div>
+        );
+      }
+
+      const routes = [
+        routeState<PageState>()({
+          path: "/",
+          loader,
+          component: Page,
+        }),
+      ];
+
+      render(<Router routes={routes} />);
+      expect(screen.getByText("Data: loaded")).toBeInTheDocument();
+      expect(loader).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"));
+      });
+
+      expect(screen.getByText("Count: 1")).toBeInTheDocument();
+      expect(screen.getByText("Data: loaded")).toBeInTheDocument();
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-execute any loader in the matched stack on setState", async () => {
+      type PageState = { count: number };
+      const parentLoader = vi.fn(() => ({ title: "Users" }));
+      const childLoader = vi.fn(() => ({ name: "Alice" }));
+
+      setupNavigationMock("http://localhost/users/123");
+
+      function Layout({ data }: { data: { title: string } }) {
+        return (
+          <div>
+            <h1>{data.title}</h1>
+            <Outlet />
+          </div>
+        );
+      }
+
+      function UserDetail({
+        data,
+        state,
+        setState,
+      }: RouteComponentProps<{ id: string }, PageState> & {
+        data: { name: string };
+      }) {
+        return (
+          <div>
+            <span>Name: {data.name}</span>
+            <span>Count: {state?.count ?? 0}</span>
+            <button onClick={() => void setState({ count: 1 })}>Save</button>
+          </div>
+        );
+      }
+
+      const routes = [
+        route({
+          path: "/users",
+          loader: parentLoader,
+          component: Layout,
+          children: [
+            routeState<PageState>()({
+              path: ":id",
+              loader: childLoader,
+              component: UserDetail,
+            }),
+          ],
+        }),
+      ];
+
+      render(<Router routes={routes} />);
+      expect(parentLoader).toHaveBeenCalledTimes(1);
+      expect(childLoader).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button"));
+      });
+
+      expect(screen.getByText("Count: 1")).toBeInTheDocument();
+      expect(parentLoader).toHaveBeenCalledTimes(1);
+      expect(childLoader).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-execute the loader on resetState", async () => {
+      type PageState = { count: number };
+      const loader = vi.fn(() => ({ message: "loaded" }));
+
+      function Page({
+        data,
+        state,
+        setStateSync,
+        resetState,
+      }: RouteComponentProps<Record<string, never>, PageState> & {
+        data: { message: string };
+      }) {
+        return (
+          <div>
+            <span>Data: {data.message}</span>
+            <span>Count: {state?.count ?? "none"}</span>
+            <button onClick={() => setStateSync({ count: 10 })}>Set</button>
+            <button onClick={() => void resetState()}>Reset</button>
+          </div>
+        );
+      }
+
+      const routes = [
+        routeState<PageState>()({
+          path: "/",
+          loader,
+          component: Page,
+        }),
+      ];
+
+      render(<Router routes={routes} />);
+      act(() => {
+        fireEvent.click(screen.getByText("Set"));
+      });
+      expect(screen.getByText("Count: 10")).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Reset"));
+      });
+
+      expect(screen.getByText("Count: none")).toBeInTheDocument();
+      expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-executes the loader when a replace navigation changes the URL", () => {
+      const loader = vi.fn(() => ({ message: "loaded" }));
+
+      const mockNavigation = setupNavigationMock("http://localhost/a");
+
+      function Page({ params }: { params: { page: string }; data: { message: string } }) {
+        return <div>Page: {params.page}</div>;
+      }
+
+      const routes = [
+        route({
+          path: "/:page",
+          loader,
+          component: Page,
+        }),
+      ];
+
+      render(<Router routes={routes} />);
+      expect(screen.getByText("Page: a")).toBeInTheDocument();
+      expect(loader).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        mockNavigation.navigate("http://localhost/b", { history: "replace" });
+      });
+
+      expect(screen.getByText("Page: b")).toBeInTheDocument();
+      expect(loader).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/router/src/core/NavigationAPIAdapter.ts
+++ b/packages/router/src/core/NavigationAPIAdapter.ts
@@ -12,6 +12,7 @@ import {
   executeLoaders,
   createLoaderRequest,
   createActionRequest,
+  carryOverLoaderCacheForEntry,
   clearLoaderCacheForEntry,
 } from "./loaderCache.js";
 
@@ -115,10 +116,16 @@ export class NavigationAPIAdapter implements RouterAdapter {
       (event) => {
         // NavigationCurrentEntryChangeEvent.navigationType is null
         // when the change was caused by updateCurrentEntry()
-        const navigationType = (event as NavigationCurrentEntryChangeEvent).navigationType;
+        const { navigationType, from } = event as NavigationCurrentEntryChangeEvent;
         if (navigationType === null) {
           callback({ kind: "state" });
         } else {
+          if (navigationType === "replace") {
+            // Must happen before the callback so subscribers never render
+            // (and execute loaders) with the new entry's cache key while it
+            // is still empty.
+            this.#carryOverLoaderCacheAcrossReplace(from);
+          }
           callback({
             kind: "navigation",
             navigationType,
@@ -193,6 +200,34 @@ export class NavigationAPIAdapter implements RouterAdapter {
         { signal },
       );
     }
+  }
+
+  /**
+   * Preserve cached loader results across a same-URL replace navigation.
+   *
+   * A replace assigns a new NavigationHistoryEntry.id, which changes the
+   * loader cache key. When the URL is unchanged — notably the async
+   * `setState`/`resetState`, which persist state via a replace to the
+   * current URL — the loaders' inputs (URL, params) are identical, so
+   * re-executing them would refetch the same data just to save UI state.
+   * Copy the previous entry's cached results to the new entry's key
+   * instead. (Loaders cannot observe navigation state, so a state change
+   * never requires revalidation; `navigation.reload()` remains the way to
+   * refetch on the same URL.)
+   *
+   * Form submissions are unaffected: their revalidation explicitly clears
+   * the new entry's cache before executing loaders with the action result.
+   */
+  #carryOverLoaderCacheAcrossReplace(from: NavigationHistoryEntry): void {
+    const to = navigation.currentEntry;
+    if (!to?.url || !from.url || from.url !== to.url || from.id === to.id) {
+      return;
+    }
+    // The source must be the previous entry's *effective* key so results
+    // cached under a reload generation (`:rN` suffix) are found. The new
+    // entry has no reload count yet, so its effective key is the composite.
+    const fromKey = this.#effectiveKey(`${from.id}|${from.url}`);
+    carryOverLoaderCacheForEntry(fromKey, `${to.id}|${to.url}`);
   }
 
   /**

--- a/packages/router/src/core/loaderCache.ts
+++ b/packages/router/src/core/loaderCache.ts
@@ -107,6 +107,26 @@ export function clearLoaderCache(): void {
 }
 
 /**
+ * Copy cached loader results from one entry key to another.
+ *
+ * Used to preserve results across same-URL replace navigations (notably the
+ * async `setState`/`resetState`), where the new entry id would otherwise
+ * change the cache key and re-execute every loader for the same URL.
+ */
+export function carryOverLoaderCacheForEntry(fromEntryKey: string, toEntryKey: string): void {
+  const fromPrefix = `${fromEntryKey}:`;
+  const carried: [suffix: string, value: unknown][] = [];
+  for (const [key, value] of loaderCache) {
+    if (key.startsWith(fromPrefix)) {
+      carried.push([key.slice(fromPrefix.length), value]);
+    }
+  }
+  for (const [suffix, value] of carried) {
+    loaderCache.set(`${toEntryKey}:${suffix}`, value);
+  }
+}
+
+/**
  * Clear loader cache entries for a specific navigation entry.
  * Called when a NavigationHistoryEntry is disposed (removed from history stack).
  */


### PR DESCRIPTION
Closes #204

## Problem

The async `setState`/`resetState` props persist navigation state via a replace navigation to the current URL. A replace assigns a new `NavigationHistoryEntry.id`, which changed the loader cache composite key (`${entry.id}|${url}`), so **every loader in the matched route stack re-executed** — refetching data just to save UI state like scroll position or filters. The sync variants (`setStateSync`/`resetStateSync`) did not have this problem because `updateCurrentEntry()` keeps the entry id.

## Why carry-over is safe

Loaders receive only `{ params, request, signal, actionResult }` — navigation state is not part of `LoaderArgs`, so loaders cannot depend on it and a state-only replace never requires revalidation. (The sync setters already demonstrated this: they update state without ever re-running loaders.)

## Fix

`NavigationAPIAdapter` now listens for replace navigations in its `currententrychange` handler — which fires at commit time, before the intercept handler runs and before any render — and, when the URL is unchanged and the entry id changed, copies the previous entry's cached loader results to the new entry's cache key. The source key goes through `#effectiveKey` so results cached under a reload generation (`:rN` suffix) are found too.

Everything else keeps its behavior by construction:

- Replace navigations to a **different** URL still execute loaders fresh (URLs don't match, no carry-over).
- `navigation.reload()` still re-executes loaders via the reload counter, and remains the way to refetch on the same URL.
- Form-submission revalidation is unaffected: its handler explicitly clears the new entry's cache before executing loaders with the action result.
- WebKit Private Browsing needs no special handling: `currententrychange` doesn't fire there, but the entry id doesn't change either, so the cache key is already stable.

## Tests

Four new cases in `state.test.tsx`:

- `setState` no longer re-executes the loader (data and updated state both render)
- Nested routes: no loader in the matched stack re-executes on `setState`
- `resetState` no longer re-executes the loader
- Guard: a replace navigation to a different URL still re-executes the loader

Verified the tests catch the regression: with the fix stashed, the three state tests fail (loader called twice) and the guard passes.

## Docs

Updated the three places describing this behavior: the "Push and Replace" section and summary table in the loaders guide (now distinguishing same-URL replaces and noting loaders cannot observe navigation state), and the `setState` descriptions in the Types and Utilities API pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJdKnKtgjmhHFfqa2K5t1Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJdKnKtgjmhHFfqa2K5t1Q)_