### PR TITLE
fix: support URLPattern modifiers (?, +, *) in non-exact parent routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,16 @@ Full documentation is available at [router.funstack.work](https://router.funstac
 
 FUNSTACK Router uses the [URLPattern API](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern) for path matching.
 
-| Pattern      | Example        | Matches         |
-| ------------ | -------------- | --------------- |
-| `/users`     | `/users`       | Exact match     |
-| `/users/:id` | `/users/123`   | Named parameter |
-| `/files/*`   | `/files/a/b/c` | Wildcard        |
+| Pattern           | Example                | Matches                        |
+| ----------------- | ---------------------- | ------------------------------ |
+| `/users`          | `/users`               | Exact match                    |
+| `/users/:id`      | `/users/123`           | Named parameter                |
+| `/docs/:section?` | `/docs`, `/docs/intro` | Optional parameter             |
+| `/files/:path+`   | `/files/a/b`           | Repeated parameter (1 or more) |
+| `/users/:id(\d+)` | `/users/123`           | Parameter with regex           |
+| `/files/*`        | `/files/a/b/c`         | Wildcard                       |
+
+These patterns also work on parent routes: the matched portion is consumed as a prefix and the rest of the pathname is matched against child routes.
 
 ## License
 

--- a/packages/router/src/__tests__/matchRoutes.test.ts
+++ b/packages/router/src/__tests__/matchRoutes.test.ts
@@ -225,6 +225,182 @@ describe("matchRoutes", () => {
     });
   });
 
+  describe("URLPattern modifiers in non-exact routes", () => {
+    it("matches child under parent with optional param (:section?) present", () => {
+      const routes = internalRoutes([
+        {
+          path: "/docs/:section?",
+          component: () => null,
+          children: [{ path: "/page/:id", component: () => null }],
+        },
+      ]);
+
+      const result = matchRoutes(routes, "/docs/intro/page/5");
+      expect(result).toHaveLength(2);
+      expect(result![0].pathname).toBe("/docs/intro");
+      expect(result![0].params).toEqual({ section: "intro" });
+      expect(result![1].params).toEqual({ section: "intro", id: "5" });
+    });
+
+    it("matches child under parent with optional param (:section?) absent", () => {
+      const routes = internalRoutes([
+        {
+          path: "/docs/:section?",
+          component: () => null,
+          children: [{ path: "/page/:id", component: () => null }],
+        },
+      ]);
+
+      const result = matchRoutes(routes, "/docs/page/5");
+      expect(result).toHaveLength(2);
+      expect(result![0].pathname).toBe("/docs");
+      expect(result![0].params).toEqual({});
+      expect(result![1].params).toEqual({ id: "5" });
+    });
+
+    it("prefers the longest consumed prefix when ambiguous", () => {
+      const routes = internalRoutes([
+        {
+          path: "/docs/:section?",
+          component: () => null,
+          children: [{ path: "/page/:id", component: () => null }],
+        },
+      ]);
+
+      // Both section="page" and section absent could lead to a child match;
+      // the longer consumed prefix (greedy) wins.
+      const result = matchRoutes(routes, "/docs/page/page/5");
+      expect(result).toHaveLength(2);
+      expect(result![1].params).toEqual({ section: "page", id: "5" });
+    });
+
+    it("matches child under parent with repeated param (:path+)", () => {
+      const routes = internalRoutes([
+        {
+          path: "/files/:path+",
+          component: () => null,
+          children: [{ path: "/meta", component: () => null }],
+        },
+      ]);
+
+      const result = matchRoutes(routes, "/files/a/b/meta");
+      expect(result).toHaveLength(2);
+      expect(result![0].pathname).toBe("/files/a/b");
+      expect(result![0].params).toEqual({ path: "a/b" });
+    });
+
+    it(":path+ parent requires at least one segment before children", () => {
+      const routes = internalRoutes([
+        {
+          path: "/files/:path+",
+          component: () => null,
+          children: [{ path: "/meta", component: () => null }],
+        },
+      ]);
+
+      // Consuming just "/files" would leave "/meta" for the child, but
+      // :path+ requires at least one segment, so nothing matches.
+      expect(matchRoutes(routes, "/files/meta")).toBeNull();
+      expect(matchRoutes(routes, "/files")).toBeNull();
+    });
+
+    it("matches child under parent with zero-or-more param (:path*)", () => {
+      const routes = internalRoutes([
+        {
+          path: "/files/:path*",
+          component: () => null,
+          children: [{ path: "/meta", component: () => null }],
+        },
+      ]);
+
+      const withSegments = matchRoutes(routes, "/files/a/b/meta");
+      expect(withSegments).toHaveLength(2);
+      expect(withSegments![0].params).toEqual({ path: "a/b" });
+
+      const withoutSegments = matchRoutes(routes, "/files/meta");
+      expect(withoutSegments).toHaveLength(2);
+      expect(withoutSegments![0].pathname).toBe("/files");
+      expect(withoutSegments![0].params).toEqual({});
+    });
+
+    it("matches child under parent with group modifier ({/:section}?)", () => {
+      const routes = internalRoutes([
+        {
+          path: "/docs{/:section}?",
+          component: () => null,
+          children: [{ path: "/page/:id", component: () => null }],
+        },
+      ]);
+
+      const absent = matchRoutes(routes, "/docs/page/5");
+      expect(absent).toHaveLength(2);
+      expect(absent![0].pathname).toBe("/docs");
+      expect(absent![1].params).toEqual({ id: "5" });
+
+      const present = matchRoutes(routes, "/docs/intro/page/5");
+      expect(present).toHaveLength(2);
+      expect(present![1].params).toEqual({ section: "intro", id: "5" });
+    });
+
+    it("matches child under parent with regex group param", () => {
+      const routes = internalRoutes([
+        {
+          path: "/users/:id(\\d+)",
+          component: () => null,
+          children: [{ path: "/posts", component: () => null }],
+        },
+      ]);
+
+      const result = matchRoutes(routes, "/users/123/posts");
+      expect(result).toHaveLength(2);
+      expect(result![0].params).toEqual({ id: "123" });
+
+      expect(matchRoutes(routes, "/users/abc/posts")).toBeNull();
+    });
+
+    it("matches child under parent with wildcard (*)", () => {
+      const routes = internalRoutes([
+        {
+          path: "/files/*",
+          component: () => null,
+          children: [{ path: "/meta", component: () => null }],
+        },
+      ]);
+
+      const result = matchRoutes(routes, "/files/a/b/meta");
+      expect(result).toHaveLength(2);
+      expect(result![0].pathname).toBe("/files/a/b");
+      expect(result![1].route.path).toBe("/meta");
+    });
+
+    it("non-exact leaf with :path+ consumes greedily", () => {
+      const routes = internalRoutes([
+        { path: "/files/:path+", component: () => null, exact: false },
+      ]);
+
+      const result = matchRoutes(routes, "/files/a/b");
+      expect(result).toHaveLength(1);
+      expect(result![0].params).toEqual({ path: "a/b" });
+      expect(result![0].pathname).toBe("/files/a/b");
+    });
+
+    it("optional param parent falls back to requireChildren: false when no child matches", () => {
+      const routes = internalRoutes([
+        {
+          path: "/docs/:section?",
+          component: () => null,
+          requireChildren: false,
+          children: [{ path: "/page/:id", component: () => null }],
+        },
+      ]);
+
+      const result = matchRoutes(routes, "/docs/intro");
+      expect(result).toHaveLength(1);
+      expect(result![0].params).toEqual({ section: "intro" });
+      expect(result![0].pathname).toBe("/docs/intro");
+    });
+  });
+
   describe("pathless routes", () => {
     it("pathless route always matches any pathname", () => {
       const routes = internalRoutes([{ component: () => null }]);

--- a/packages/router/src/__tests__/route.test-d.ts
+++ b/packages/router/src/__tests__/route.test-d.ts
@@ -43,6 +43,64 @@ describe("route() type inference", () => {
     >();
   });
 
+  it("strips URLPattern modifiers from param names", () => {
+    const optional = route({
+      id: "docs",
+      path: "/docs/:section?",
+      component: () => null,
+    });
+    expectTypeOf(optional).toEqualTypeOf<
+      TypefulOpaqueRouteDefinition<"docs", { section: string }, undefined, undefined>
+    >();
+
+    const repeated = route({
+      id: "files",
+      path: "/files/:path+",
+      component: () => null,
+    });
+    expectTypeOf(repeated).toEqualTypeOf<
+      TypefulOpaqueRouteDefinition<"files", { path: string }, undefined, undefined>
+    >();
+
+    const zeroOrMore = route({
+      id: "assets",
+      path: "/assets/:rest*",
+      component: () => null,
+    });
+    expectTypeOf(zeroOrMore).toEqualTypeOf<
+      TypefulOpaqueRouteDefinition<"assets", { rest: string }, undefined, undefined>
+    >();
+  });
+
+  it("strips regex groups and group delimiters from param names", () => {
+    const regex = route({
+      id: "user",
+      path: "/users/:id(\\d+)",
+      component: () => null,
+    });
+    expectTypeOf(regex).toEqualTypeOf<
+      TypefulOpaqueRouteDefinition<"user", { id: string }, undefined, undefined>
+    >();
+
+    const grouped = route({
+      id: "docs",
+      path: "/docs{/:section}?",
+      component: () => null,
+    });
+    expectTypeOf(grouped).toEqualTypeOf<
+      TypefulOpaqueRouteDefinition<"docs", { section: string }, undefined, undefined>
+    >();
+
+    const regexWithModifier = route({
+      id: "post",
+      path: "/posts/:slug(\\w+)?",
+      component: () => null,
+    });
+    expectTypeOf(regexWithModifier).toEqualTypeOf<
+      TypefulOpaqueRouteDefinition<"post", { slug: string }, undefined, undefined>
+    >();
+  });
+
   it("infers data type from loader", () => {
     const r = route({
       id: "user",

--- a/packages/router/src/core/matchRoutes.ts
+++ b/packages/router/src/core/matchRoutes.ts
@@ -50,8 +50,7 @@ function matchRoute(
         return SKIPPED; // pathless always matches
       }
       const isExact = route.exact ?? !hasChildren;
-      const { matched } = matchPath(route.path, pathname, isExact);
-      if (matched) return SKIPPED;
+      if (matchPath(route.path, pathname, isExact).length > 0) return SKIPPED;
     }
     return null;
   }
@@ -101,30 +100,27 @@ function matchRoute(
 
   const isExact = route.exact ?? !hasChildren;
 
-  const { matched, params, consumedPathname } = matchPath(route.path, pathname, isExact);
+  const candidates = matchPath(route.path, pathname, isExact);
 
-  if (!matched) {
+  if (candidates.length === 0) {
     return null;
   }
 
-  const result: MatchedRoute = {
-    route,
-    params,
-    pathname: consumedPathname,
-  };
+  if (!hasChildren) {
+    const { params, consumedPathname } = candidates[0]!;
+    return [{ route, params, pathname: consumedPathname }];
+  }
 
-  // If this route has children, try to match them
-  if (hasChildren) {
+  // Try each candidate consumed prefix (longest first), backtracking to a
+  // shorter prefix when no child matches the remaining pathname.
+  let anyChildSkipped = false;
+  for (const { params, consumedPathname } of candidates) {
     // Calculate remaining pathname, ensuring it starts with /
     let remainingPathname = pathname.slice(consumedPathname.length);
     if (!remainingPathname.startsWith("/")) {
       remainingPathname = "/" + remainingPathname;
     }
-    if (remainingPathname === "") {
-      remainingPathname = "/";
-    }
 
-    let anyChildSkipped = false;
     for (const child of route.children!) {
       const childMatch = matchRoute(child, remainingPathname, options);
       if (childMatch === SKIPPED) {
@@ -134,7 +130,7 @@ function matchRoute(
       if (childMatch) {
         // Merge params from parent into children
         return [
-          result,
+          { route, params, pathname: consumedPathname },
           ...childMatch.map((m) => ({
             ...m,
             params: { ...params, ...m.params },
@@ -143,82 +139,130 @@ function matchRoute(
       }
     }
 
-    if (anyChildSkipped) {
-      if (route.component) return [result]; // render as shell
-      return SKIPPED; // propagate
-    }
-
-    // If no children matched - only valid if requireChildren is false and route has a component
-    if (route.component && route.requireChildren === false) {
-      return [result];
-    }
-
-    // During SSR, path-based route with component matches alone (SSR shell)
-    if (skipLoaders && route.component) {
-      return [result];
-    }
-
-    return null;
+    // A skipped child would match on the client; stop here so a shorter
+    // prefix cannot produce a different tree during SSR.
+    if (anyChildSkipped) break;
   }
 
-  return [result];
+  const { params, consumedPathname } = candidates[0]!;
+  const result: MatchedRoute = {
+    route,
+    params,
+    pathname: consumedPathname,
+  };
+
+  if (anyChildSkipped) {
+    if (route.component) return [result]; // render as shell
+    return SKIPPED; // propagate
+  }
+
+  // If no children matched - only valid if requireChildren is false and route has a component
+  if (route.component && route.requireChildren === false) {
+    return [result];
+  }
+
+  // During SSR, path-based route with component matches alone (SSR shell)
+  if (skipLoaders && route.component) {
+    return [result];
+  }
+
+  return null;
+}
+
+type PathMatchCandidate = {
+  params: Record<string, string>;
+  consumedPathname: string;
+};
+
+/**
+ * Matches a pattern segment that always consumes exactly one pathname
+ * segment: either a literal without URLPattern syntax, or a plain `:param`.
+ */
+const SINGLE_SEGMENT_PATTERN = /^(?::[A-Za-z0-9_$]+|[^:*?+(){}\\]*)$/;
+
+function consumesOneSegmentEach(pattern: string): boolean {
+  return pattern.split("/").every((segment) => SINGLE_SEGMENT_PATTERN.test(segment));
 }
 
 /**
  * Match a path pattern against a pathname.
+ *
+ * For non-exact (prefix) matches, the pattern may consume a variable number
+ * of pathname segments (e.g. with `?`, `+`, `*` modifiers), so multiple
+ * candidates can be returned, ordered from longest to shortest consumed
+ * prefix. Returns an empty array if the pattern doesn't match at all.
  */
-function matchPath(
-  pattern: string,
-  pathname: string,
-  exact: boolean,
-): {
-  matched: boolean;
-  params: Record<string, string>;
-  consumedPathname: string;
-} {
+function matchPath(pattern: string, pathname: string, exact: boolean): PathMatchCandidate[] {
   // Normalize pattern
   const normalizedPattern = pattern.startsWith("/") ? pattern : `/${pattern}`;
 
-  // Build URLPattern
-  let urlPatternPath: string;
   if (exact) {
-    urlPatternPath = normalizedPattern;
-  } else if (normalizedPattern === "/") {
-    // Special case: root path as prefix matches anything
-    urlPatternPath = "/*";
-  } else {
-    // For other prefix matches, add optional wildcard suffix
-    urlPatternPath = `${normalizedPattern}{/*}?`;
+    const match = new URLPattern({ pathname: normalizedPattern }).exec({
+      pathname,
+    });
+    if (!match) {
+      return [];
+    }
+    return [{ params: extractParams(match), consumedPathname: pathname }];
   }
 
-  const urlPattern = new URLPattern({ pathname: urlPatternPath });
-
-  const match = urlPattern.exec({ pathname });
-  if (!match) {
-    return { matched: false, params: {}, consumedPathname: "" };
+  if (normalizedPattern === "/") {
+    // Special case: root path as prefix matches anything, consuming just "/"
+    if (!new URLPattern({ pathname: "/*" }).test({ pathname })) {
+      return [];
+    }
+    return [{ params: {}, consumedPathname: "/" }];
   }
 
-  // Extract params (excluding the wildcard group "0")
+  // For prefix matches, add optional wildcard suffix
+  const prefixMatch = new URLPattern({
+    pathname: `${normalizedPattern}{/*}?`,
+  }).exec({ pathname });
+  if (!prefixMatch) {
+    return [];
+  }
+
+  if (consumesOneSegmentEach(normalizedPattern)) {
+    // Fast path: one pathname segment consumed per pattern segment
+    const patternSegments = normalizedPattern.split("/").filter(Boolean);
+    const pathnameSegments = pathname.split("/").filter(Boolean);
+    return [
+      {
+        params: extractParams(prefixMatch),
+        consumedPathname: "/" + pathnameSegments.slice(0, patternSegments.length).join("/"),
+      },
+    ];
+  }
+
+  // URLPattern syntax like `?`, `+`, `*` and regex groups can consume a
+  // variable number of segments, so the consumed prefix cannot be derived
+  // from segment counts. Instead, match the bare pattern against every
+  // pathname prefix, longest first.
+  const basePattern = new URLPattern({ pathname: normalizedPattern });
+  const segments = pathname.split("/").filter(Boolean);
+  const candidates: PathMatchCandidate[] = [];
+  for (let count = segments.length; count >= 0; count--) {
+    const prefix = count === 0 ? "/" : "/" + segments.slice(0, count).join("/");
+    const match = basePattern.exec({ pathname: prefix });
+    if (match) {
+      candidates.push({
+        params: extractParams(match),
+        consumedPathname: prefix,
+      });
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Extract params from a URLPattern match (excluding the wildcard group "0").
+ */
+function extractParams(match: URLPatternResult): Record<string, string> {
   const params: Record<string, string> = {};
   for (const [key, value] of Object.entries(match.pathname.groups)) {
     if (value !== undefined && key !== "0") {
       params[key] = value;
     }
   }
-
-  // Calculate consumed pathname
-  let consumedPathname: string;
-  if (exact) {
-    consumedPathname = pathname;
-  } else if (normalizedPattern === "/") {
-    // Root pattern consumes just "/"
-    consumedPathname = "/";
-  } else {
-    // For prefix matches, calculate based on pattern segments
-    const patternSegments = normalizedPattern.split("/").filter(Boolean);
-    const pathnameSegments = pathname.split("/").filter(Boolean);
-    consumedPathname = "/" + pathnameSegments.slice(0, patternSegments.length).join("/");
-  }
-
-  return { matched: true, params, consumedPathname };
+  return params;
 }

--- a/packages/router/src/route.ts
+++ b/packages/router/src/route.ts
@@ -4,13 +4,31 @@ const routeDefinitionSymbol = Symbol();
 const partialRouteDefinitionSymbol = Symbol();
 
 /**
+ * Strips URLPattern syntax following a parameter name: modifiers (`?`, `+`,
+ * `*`), regex groups, and group delimiters.
+ * E.g., "section?" -> "section", "path+" -> "path", "id(\\d+)" -> "id",
+ * "section}?" (from "/docs{/:section}?") -> "section"
+ */
+type StripParamModifiers<T extends string> = T extends `${infer Name}(${string}`
+  ? StripParamModifiers<Name>
+  : T extends `${infer Name}}${string}`
+    ? StripParamModifiers<Name>
+    : T extends `${infer Name}?`
+      ? StripParamModifiers<Name>
+      : T extends `${infer Name}+`
+        ? StripParamModifiers<Name>
+        : T extends `${infer Name}*`
+          ? StripParamModifiers<Name>
+          : T;
+
+/**
  * Extracts parameter names from a path pattern.
  * E.g., "/users/:id/posts/:postId" -> "id" | "postId"
  */
 type ExtractParams<T extends string> = T extends `${string}:${infer Param}/${infer Rest}`
-  ? Param | ExtractParams<`/${Rest}`>
+  ? StripParamModifiers<Param> | ExtractParams<`/${Rest}`>
   : T extends `${string}:${infer Param}`
-    ? Param
+    ? StripParamModifiers<Param>
     : never;
 
 /**


### PR DESCRIPTION
Closes #205

## Problem

Non-exact (parent) routes computed the consumed pathname prefix by counting pattern segments, assuming one pathname segment per pattern segment. Any URLPattern syntax where the number of matched segments can differ from the number of pattern segments (`?`, `+`, `*` modifiers, regex groups, wildcards) produced a wrong consumed prefix, so children received the wrong remaining pathname and the whole route tree failed to match:

```tsx
// failed to match /docs/page/5 (with :section absent)
route({ path: "/docs/:section?", component: Layout, children: [
  route({ path: "/page/:id", component: Page }),
]})

// failed to match /files/a/b/meta
route({ path: "/files/:path+", component: Layout, children: [
  route({ path: "/meta", component: Meta }),
]})
```

## Fix

**Runtime (`matchRoutes.ts`):** `matchPath` now returns match candidates instead of a single result.

- Simple patterns (literal segments and plain `:param`s) keep the original segment-counting fast path, so the common case does no extra work.
- Patterns with variable-length syntax match the bare pattern (without the `{/*}?` suffix) against every pathname prefix, longest first. `matchRoute` backtracks to a shorter consumed prefix when no child matches the remainder, so `/docs/:section?` matches `/docs/page/5` with `section` absent.
- Ambiguous matches prefer the longest consumed prefix (greedy), matching URLPattern's own semantics.
- SSR `SKIPPED` semantics are preserved: once a candidate's child is skipped, shorter prefixes aren't tried, so the server can't render a different tree than the client would hydrate.

**Types (`route.ts`):** `ExtractParams` now strips modifiers, regex groups, and group delimiters from param names, so `path: "/docs/:section?"` types params as `{ section: string }` instead of `{ "section?": string }` (also handles `:id(\d+)` and `{/:section}?`).

**Docs:** extended the README Path Patterns table with optional/repeated/regex parameter rows and a note that patterns work as prefixes on parent routes.

## Tests

13 new cases: 11 runtime tests pinning `?`/`+`/`*`/regex-group/brace-group behavior in parent routes (including greedy preference, backtracking, `:path+` minimum-segment enforcement, and `requireChildren: false` fallback) and 2 type-level tests for modifier stripping. All 299 tests pass; typecheck, lint, and format are clean.

Note: `pnpm build` fails for the docs and example-rsc packages in the dev container with `ReferenceError: URLPattern is not defined` — this is pre-existing on the base commit (Node 22 has no global URLPattern) and unrelated to this change. The router package builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016HWo3h7xx3i3yB7AjoBTpP

---
_Generated by [Claude Code](https://claude.ai/code/session_016HWo3h7xx3i3yB7AjoBTpP)_