### PR TITLE
fix: percent-decode route params extracted from the pathname

### DIFF
--- a/packages/docs/src/pages/GettingStartedPage.tsx
+++ b/packages/docs/src/pages/GettingStartedPage.tsx
@@ -119,6 +119,10 @@ const routes = [
     component: UserProfile,
   }),
 ];`}</CodeBlock>
+        <p>
+          Parameter values are percent-decoded: navigating to <code>/users/Jo%C3%A3o</code> yields{" "}
+          <code>params.userId === "João"</code>.
+        </p>
       </section>
 
       <section>

--- a/packages/router/src/__tests__/matchRoutes.test.ts
+++ b/packages/router/src/__tests__/matchRoutes.test.ts
@@ -53,6 +53,44 @@ describe("matchRoutes", () => {
       expect(result).toHaveLength(1);
       expect(result![0].params).toEqual({ userId: "42", postId: "99" });
     });
+
+    it("percent-decodes parameter values", () => {
+      const routes = internalRoutes([{ path: "/users/:name", component: () => null }]);
+
+      const result = matchRoutes(routes, "/users/Jo%C3%A3o");
+      expect(result).toHaveLength(1);
+      expect(result![0].params).toEqual({ name: "João" });
+    });
+
+    it("percent-decodes spaces and reserved characters", () => {
+      const routes = internalRoutes([{ path: "/files/:name", component: () => null }]);
+
+      const result = matchRoutes(routes, "/files/hello%20world%3F");
+      expect(result).toHaveLength(1);
+      expect(result![0].params).toEqual({ name: "hello world?" });
+    });
+
+    it("percent-decodes params inherited from parent routes", () => {
+      const routes = internalRoutes([
+        {
+          path: "/users/:name",
+          component: () => null,
+          children: [{ path: "/posts/:title", component: () => null }],
+        },
+      ]);
+
+      const result = matchRoutes(routes, "/users/Jo%C3%A3o/posts/ol%C3%A1");
+      expect(result).toHaveLength(2);
+      expect(result![1].params).toEqual({ name: "João", title: "olá" });
+    });
+
+    it("falls back to the raw value for malformed percent sequences", () => {
+      const routes = internalRoutes([{ path: "/users/:name", component: () => null }]);
+
+      const result = matchRoutes(routes, "/users/100%zz");
+      expect(result).toHaveLength(1);
+      expect(result![0].params).toEqual({ name: "100%zz" });
+    });
   });
 
   describe("nested routes", () => {

--- a/packages/router/src/core/matchRoutes.ts
+++ b/packages/router/src/core/matchRoutes.ts
@@ -256,13 +256,28 @@ function matchPath(pattern: string, pathname: string, exact: boolean): PathMatch
 
 /**
  * Extract params from a URLPattern match (excluding the wildcard group "0").
+ *
+ * URLPattern matches against the percent-encoded pathname and returns group
+ * values as-is, so param values are decoded here before being exposed.
  */
 function extractParams(match: URLPatternResult): Record<string, string> {
   const params: Record<string, string> = {};
   for (const [key, value] of Object.entries(match.pathname.groups)) {
     if (value !== undefined && key !== "0") {
-      params[key] = value;
+      params[key] = decodeParam(value);
     }
   }
   return params;
+}
+
+/**
+ * Percent-decode a param value, falling back to the raw value for malformed
+ * sequences (e.g. a lone `%`) rather than failing the whole match.
+ */
+function decodeParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }


### PR DESCRIPTION
Closes #206

## Problem

Navigating to `/users/Jo%C3%A3o` with `path: "/users/:name"` yielded `params.name === "Jo%C3%A3o"` instead of `"João"`. `URLPattern.exec()` matches against the percent-encoded pathname (`location.pathname` is always in encoded form) and returns group values as-is, so any param containing spaces, unicode, or reserved characters reached loaders, actions, and components percent-encoded.

## Fix

- `extractParams` in `packages/router/src/core/matchRoutes.ts` now decodes each group value with `decodeURIComponent`, falling back to the raw value for malformed sequences (e.g. a lone `%`) rather than failing the match. All matching paths (exact, fast prefix, and backtracking) funnel through `extractParams`, so merged parent params are covered too.
- `consumedPathname` intentionally stays encoded — it is used to slice the remaining pathname for child matching.
- Since the input pathname is guaranteed to be in encoded form, decoding here cannot double-decode.

## Tests & docs

- Added tests for unicode decoding, spaces/reserved characters, params inherited from parent routes, and the malformed-sequence fallback.
- Documented the decoding behavior in the Route Parameters section of the Getting Started docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1GkQiKvX1SHpFs9ojyj1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1GkQiKvX1SHpFs9ojyj1m)_