### PR TITLE
fix: preserve navigation state in setSearchParams and add replace option

### DIFF
--- a/packages/docs/src/pages/ApiHooksPage.tsx
+++ b/packages/docs/src/pages/ApiHooksPage.tsx
@@ -48,15 +48,12 @@ function SearchPage() {
 }`}</CodeBlock>
         <p>The setter accepts an optional second argument with navigation options:</p>
         <CodeBlock language="tsx">{`// Push a new history entry instead of replacing the current one
-setSearchParams({ q: newQuery }, { replace: false });
-
-// Associate navigation state with the entry
-setSearchParams({ q: newQuery }, { state: { fromSearch: true } });`}</CodeBlock>
+setSearchParams({ q: newQuery }, { replace: false });`}</CodeBlock>
         <p>
           By default (<code>replace: true</code>), the setter replaces the current history entry and
           preserves its navigation state, including per-route state set via <code>setState</code>.
-          With <code>replace: false</code>, a new entry is pushed without state. In both cases, an
-          explicit <code>state</code> option takes precedence.
+          With <code>replace: false</code>, a new entry is pushed instead, so the change can be
+          undone with the browser's Back button.
         </p>
       </article>
 

--- a/packages/docs/src/pages/ApiHooksPage.tsx
+++ b/packages/docs/src/pages/ApiHooksPage.tsx
@@ -46,6 +46,18 @@ function SearchPage() {
     setSearchParams({ q: newQuery });
   };
 }`}</CodeBlock>
+        <p>The setter accepts an optional second argument with navigation options:</p>
+        <CodeBlock language="tsx">{`// Push a new history entry instead of replacing the current one
+setSearchParams({ q: newQuery }, { replace: false });
+
+// Associate navigation state with the entry
+setSearchParams({ q: newQuery }, { state: { fromSearch: true } });`}</CodeBlock>
+        <p>
+          By default (<code>replace: true</code>), the setter replaces the current history entry and
+          preserves its navigation state, including per-route state set via <code>setState</code>.
+          With <code>replace: false</code>, a new entry is pushed without state. In both cases, an
+          explicit <code>state</code> option takes precedence.
+        </p>
       </article>
 
       <article className="api-item">

--- a/packages/docs/src/pages/ApiReferenceIndexPage.tsx
+++ b/packages/docs/src/pages/ApiReferenceIndexPage.tsx
@@ -97,7 +97,7 @@ export function ApiReferenceIndexPage() {
           </li>
           <li>
             <code>RouteDefinition</code>, <code>ActionArgs</code>, <code>LoaderArgs</code>,{" "}
-            <code>Location</code>, <code>NavigateOptions</code>
+            <code>Location</code>, <code>NavigateOptions</code>, <code>SetSearchParamsOptions</code>
           </li>
         </ul>
       </section>

--- a/packages/docs/src/pages/ApiTypesPage.tsx
+++ b/packages/docs/src/pages/ApiTypesPage.tsx
@@ -359,13 +359,11 @@ routeState<{ tab: string }>()({
         </h3>
         <CodeBlock language="typescript">{`interface SetSearchParamsOptions {
   replace?: boolean;  // default: true
-  state?: unknown;
 }`}</CodeBlock>
         <p>
-          Options for the setter returned by <code>useSearchParams</code>. When <code>state</code>{" "}
-          is omitted, a replace navigation preserves the current entry's state (including per-route
-          state set via <code>setState</code>), and a push navigation creates the new entry without
-          state.
+          Options for the setter returned by <code>useSearchParams</code>. A replace navigation
+          preserves the current entry's state (including per-route state set via{" "}
+          <code>setState</code>), while a push navigation creates the new entry without state.
         </p>
       </article>
     </div>

--- a/packages/docs/src/pages/ApiTypesPage.tsx
+++ b/packages/docs/src/pages/ApiTypesPage.tsx
@@ -352,6 +352,22 @@ routeState<{ tab: string }>()({
           navigation that triggered it.
         </p>
       </article>
+
+      <article className="api-item">
+        <h3>
+          <code>SetSearchParamsOptions</code>
+        </h3>
+        <CodeBlock language="typescript">{`interface SetSearchParamsOptions {
+  replace?: boolean;  // default: true
+  state?: unknown;
+}`}</CodeBlock>
+        <p>
+          Options for the setter returned by <code>useSearchParams</code>. When <code>state</code>{" "}
+          is omitted, a replace navigation preserves the current entry's state (including per-route
+          state set via <code>setState</code>), and a push navigation creates the new entry without
+          state.
+        </p>
+      </article>
     </div>
   );
 }

--- a/packages/router/src/__tests__/hooks.test.tsx
+++ b/packages/router/src/__tests__/hooks.test.tsx
@@ -197,61 +197,6 @@ describe("hooks", () => {
       });
     });
 
-    it("passes the state option through to the navigation", () => {
-      mockNavigation = setupNavigationMock("http://localhost/page");
-
-      function TestComponent() {
-        const [, setSearchParams] = useSearchParams();
-        return (
-          <button onClick={() => setSearchParams({ q: "new" }, { state: { custom: true } })}>
-            Update
-          </button>
-        );
-      }
-
-      const routes: RouteDefinition[] = [{ path: "/page", component: TestComponent }];
-
-      render(<Router routes={routes} />);
-      screen.getByRole("button").click();
-
-      expect(mockNavigation.navigate).toHaveBeenCalledWith("/page?q=new", {
-        history: "replace",
-        state: { custom: true },
-      });
-    });
-
-    it("clears entry state when state: undefined is passed explicitly", async () => {
-      mockNavigation = setupNavigationMock("http://localhost/page");
-
-      function TestComponent({ setStateSync }: { setStateSync?: (state: unknown) => void }) {
-        const [, setSearchParams] = useSearchParams();
-        return (
-          <div>
-            <button onClick={() => setStateSync?.({ scroll: 42 })}>SaveState</button>
-            <button onClick={() => setSearchParams({ q: "new" }, { state: undefined })}>
-              Update
-            </button>
-          </div>
-        );
-      }
-
-      const routes: RouteDefinition[] = [{ path: "/page", component: TestComponent }];
-
-      render(<Router routes={routes} />);
-
-      await act(async () => {
-        screen.getByText("SaveState").click();
-      });
-      await act(async () => {
-        screen.getByText("Update").click();
-      });
-
-      expect(mockNavigation.navigate).toHaveBeenLastCalledWith("/page?q=new", {
-        history: "replace",
-        state: undefined,
-      });
-    });
-
     it("throws when used outside Router", () => {
       function TestComponent() {
         useSearchParams();

--- a/packages/router/src/__tests__/hooks.test.tsx
+++ b/packages/router/src/__tests__/hooks.test.tsx
@@ -145,6 +145,113 @@ describe("hooks", () => {
       });
     });
 
+    it("preserves current entry state when updating search params", async () => {
+      mockNavigation = setupNavigationMock("http://localhost/page?foo=bar");
+
+      function TestComponent({ setStateSync }: { setStateSync?: (state: unknown) => void }) {
+        const [, setSearchParams] = useSearchParams();
+        return (
+          <div>
+            <button onClick={() => setStateSync?.({ scroll: 42 })}>SaveState</button>
+            <button onClick={() => setSearchParams({ q: "new" })}>Update</button>
+          </div>
+        );
+      }
+
+      const routes: RouteDefinition[] = [{ path: "/page", component: TestComponent }];
+
+      render(<Router routes={routes} />);
+
+      // Save route state on the current entry, then update search params
+      await act(async () => {
+        screen.getByText("SaveState").click();
+      });
+      await act(async () => {
+        screen.getByText("Update").click();
+      });
+
+      expect(mockNavigation.navigate).toHaveBeenLastCalledWith("/page?q=new", {
+        history: "replace",
+        state: { __routeStates: [{ scroll: 42 }] },
+      });
+    });
+
+    it("pushes a new entry when replace: false", () => {
+      mockNavigation = setupNavigationMock("http://localhost/page?foo=bar");
+
+      function TestComponent() {
+        const [, setSearchParams] = useSearchParams();
+        return (
+          <button onClick={() => setSearchParams({ q: "new" }, { replace: false })}>Update</button>
+        );
+      }
+
+      const routes: RouteDefinition[] = [{ path: "/page", component: TestComponent }];
+
+      render(<Router routes={routes} />);
+      screen.getByRole("button").click();
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("/page?q=new", {
+        history: "push",
+        state: undefined,
+      });
+    });
+
+    it("passes the state option through to the navigation", () => {
+      mockNavigation = setupNavigationMock("http://localhost/page");
+
+      function TestComponent() {
+        const [, setSearchParams] = useSearchParams();
+        return (
+          <button onClick={() => setSearchParams({ q: "new" }, { state: { custom: true } })}>
+            Update
+          </button>
+        );
+      }
+
+      const routes: RouteDefinition[] = [{ path: "/page", component: TestComponent }];
+
+      render(<Router routes={routes} />);
+      screen.getByRole("button").click();
+
+      expect(mockNavigation.navigate).toHaveBeenCalledWith("/page?q=new", {
+        history: "replace",
+        state: { custom: true },
+      });
+    });
+
+    it("clears entry state when state: undefined is passed explicitly", async () => {
+      mockNavigation = setupNavigationMock("http://localhost/page");
+
+      function TestComponent({ setStateSync }: { setStateSync?: (state: unknown) => void }) {
+        const [, setSearchParams] = useSearchParams();
+        return (
+          <div>
+            <button onClick={() => setStateSync?.({ scroll: 42 })}>SaveState</button>
+            <button onClick={() => setSearchParams({ q: "new" }, { state: undefined })}>
+              Update
+            </button>
+          </div>
+        );
+      }
+
+      const routes: RouteDefinition[] = [{ path: "/page", component: TestComponent }];
+
+      render(<Router routes={routes} />);
+
+      await act(async () => {
+        screen.getByText("SaveState").click();
+      });
+      await act(async () => {
+        screen.getByText("Update").click();
+      });
+
+      expect(mockNavigation.navigate).toHaveBeenLastCalledWith("/page?q=new", {
+        history: "replace",
+        state: undefined,
+      });
+    });
+
     it("throws when used outside Router", () => {
       function TestComponent() {
         useSearchParams();

--- a/packages/router/src/hooks/useSearchParams.ts
+++ b/packages/router/src/hooks/useSearchParams.ts
@@ -10,14 +10,6 @@ export type SetSearchParamsOptions = {
    * @default true
    */
   replace?: boolean;
-  /**
-   * State to associate with the navigation.
-   *
-   * When omitted, a replace navigation preserves the current entry's state
-   * (including per-route state set via `setState`), and a push navigation
-   * creates the new entry without state.
-   */
-  state?: unknown;
 };
 
 type SetSearchParams = (
@@ -63,18 +55,12 @@ export function useSearchParams(): [URLSearchParams, SetSearchParams] {
       url.search = newParams.toString();
 
       const replace = options?.replace ?? true;
-      // Replacing the current entry keeps its state by default; pushing
-      // creates a fresh entry without state, like any other push navigation.
-      const state =
-        options !== undefined && "state" in options
-          ? options.state
-          : replace
-            ? locationState
-            : undefined;
-
+      // Replacing the current entry keeps its state (including per-route
+      // state set via setState); pushing creates a fresh entry without
+      // state, like any other push navigation.
       void navigateAsync(url.pathname + url.search + url.hash, {
         replace,
-        state,
+        state: replace ? locationState : undefined,
       });
     },
     [currentUrl, navigateAsync, locationState],

--- a/packages/router/src/hooks/useSearchParams.ts
+++ b/packages/router/src/hooks/useSearchParams.ts
@@ -1,11 +1,31 @@
 import { useCallback, useContext } from "react";
 import { RouterContext } from "../context/RouterContext.js";
 
+/**
+ * Options for the setter returned by `useSearchParams`.
+ */
+export type SetSearchParamsOptions = {
+  /**
+   * Replace the current history entry instead of pushing a new one.
+   * @default true
+   */
+  replace?: boolean;
+  /**
+   * State to associate with the navigation.
+   *
+   * When omitted, a replace navigation preserves the current entry's state
+   * (including per-route state set via `setState`), and a push navigation
+   * creates the new entry without state.
+   */
+  state?: unknown;
+};
+
 type SetSearchParams = (
   params:
     | URLSearchParams
     | Record<string, string>
     | ((prev: URLSearchParams) => URLSearchParams | Record<string, string>),
+  options?: SetSearchParamsOptions,
 ) => void;
 
 /**
@@ -23,11 +43,11 @@ export function useSearchParams(): [URLSearchParams, SetSearchParams] {
   }
 
   const currentUrl = context.url;
-  const { navigateAsync } = context;
+  const { navigateAsync, locationState } = context;
   const searchParams = currentUrl.searchParams;
 
   const setSearchParams = useCallback<SetSearchParams>(
-    (params) => {
+    (params, options) => {
       const url = new URL(currentUrl);
 
       let newParams: URLSearchParams;
@@ -41,11 +61,23 @@ export function useSearchParams(): [URLSearchParams, SetSearchParams] {
       }
 
       url.search = newParams.toString();
+
+      const replace = options?.replace ?? true;
+      // Replacing the current entry keeps its state by default; pushing
+      // creates a fresh entry without state, like any other push navigation.
+      const state =
+        options !== undefined && "state" in options
+          ? options.state
+          : replace
+            ? locationState
+            : undefined;
+
       void navigateAsync(url.pathname + url.search + url.hash, {
-        replace: true,
+        replace,
+        state,
       });
     },
-    [currentUrl, navigateAsync],
+    [currentUrl, navigateAsync, locationState],
   );
 
   return [searchParams, setSearchParams];

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -8,7 +8,7 @@ export { Outlet } from "./Outlet.js";
 
 // Hooks
 export { useLocation } from "./hooks/useLocation.js";
-export { useSearchParams } from "./hooks/useSearchParams.js";
+export { useSearchParams, type SetSearchParamsOptions } from "./hooks/useSearchParams.js";
 export { useBlocker, type UseBlockerOptions } from "./hooks/useBlocker.js";
 export { useRouteParams } from "./hooks/useRouteParams.js";
 export { useRouteState } from "./hooks/useRouteState.js";


### PR DESCRIPTION
Closes #208

## Bug fix

`setSearchParams` performed a replace navigation without passing `state`, so the new entry's state — including the internal `__routeStates` written by `setState`/`setStateSync` — was silently wiped whenever a query param changed. The setter now reads the current entry's state from `RouterContext` and passes it through on replace navigations.

## New option

The setter accepts an optional second argument:

```ts
setSearchParams(params, { replace?: boolean }); // replace defaults to true
```

- `replace: true` (default): replaces the current entry and preserves its navigation state — previous behavior, minus the state loss.
- `replace: false`: pushes a new entry so the change can be backed out of with the browser's Back button. The new entry starts without state, consistent with every other push navigation.

The `SetSearchParamsOptions` type is exported from the package entry point.

The `state` option suggested in the issue was deliberately left out: the entry state is an internal container for per-route state and there is no public API to read raw entry state back, so exposing it would only let callers clobber route state.

## Tests & docs

- Added tests for state preservation on replace (end-to-end through `setStateSync`) and for pushing via `replace: false`.
- Updated the `useSearchParams` docs (ApiHooksPage) and added `SetSearchParamsOptions` to the types reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyJBmbRYRVoU5WLYxUs8N6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyJBmbRYRVoU5WLYxUs8N6)_