### PR TITLE
feat: add pathlessSSROutletDeferral feature flag for pathless SSR, backed by React's browser() API

### DIFF
--- a/packages/docs/src/pages/ApiComponentsPage.tsx
+++ b/packages/docs/src/pages/ApiComponentsPage.tsx
@@ -97,6 +97,21 @@ export function ApiComponentsPage() {
                 takes over. See the <a href="/learn/ssr">SSR guide</a> for details.
               </td>
             </tr>
+            <tr>
+              <td>
+                <code>features</code>
+              </td>
+              <td>
+                <code>RouterFeatures</code>
+              </td>
+              <td>
+                Opt-in feature flags that change the Router's behavior. Currently supports{" "}
+                <code>pathlessSSROutletDeferral</code>, which uses React Canary's{" "}
+                <code>browser()</code> API to defer unmatched outlet content to the browser during
+                pathless SSR (this will become the default behavior in the next major version). See
+                the <a href="/learn/ssr">SSR guide</a> for details.
+              </td>
+            </tr>
           </tbody>
         </table>
       </article>

--- a/packages/docs/src/pages/LearnSsrBasicPage.tsx
+++ b/packages/docs/src/pages/LearnSsrBasicPage.tsx
@@ -116,7 +116,7 @@ function HomePage() {
 
       <section>
         <h3>
-          Deferring Outlet Content with <code>experimentalBrowserBailout</code>
+          Deferring Outlet Content with <code>pathlessSSROutletDeferral</code>
         </h3>
         <p>
           During pathless SSR, an <code>{"<Outlet />"}</code> whose child routes are all path-based
@@ -125,13 +125,13 @@ function HomePage() {
           <a href="https://react.dev/reference/react-dom/browser">
             <code>browser()</code>
           </a>{" "}
-          API offers a cleaner way to express this: the <code>experimentalBrowserBailout</code> prop
-          makes such outlets call <code>use(browser())</code> instead, suspending server rendering
-          at the nearest <code>{"<Suspense>"}</code> boundary and deferring the outlet content to
-          the browser.
+          API offers a cleaner way to express this: the <code>pathlessSSROutletDeferral</code>{" "}
+          feature flag makes such outlets call <code>use(browser())</code> instead, suspending
+          server rendering at the nearest <code>{"<Suspense>"}</code> boundary and deferring the
+          outlet content to the browser.
         </p>
-        <CodeBlock language="tsx">{`// Opt in on the Router:
-<Router routes={routes} experimentalBrowserBailout />
+        <CodeBlock language="tsx">{`// Opt in via the Router's features prop:
+<Router routes={routes} features={{ pathlessSSROutletDeferral: true }} />
 
 // Each outlet that can be unmatched during pathless SSR
 // must be wrapped in a Suspense boundary:
@@ -153,10 +153,13 @@ function AppShell() {
           hydration mismatches.
         </p>
         <p>
-          This option requires a React build that exports <code>browser</code> from{" "}
+          This feature requires a React build that exports <code>browser</code> from{" "}
           <code>react-dom</code> (currently React Canary). On builds without the API, enabling the
-          option throws an error when the Router renders. The <code>experimental</code> prefix will
-          be dropped once <code>browser</code> becomes stable in React.
+          flag throws an error when the Router renders.
+        </p>
+        <p>
+          <code>pathlessSSROutletDeferral</code> is opt-in in the current major version and will
+          become the default behavior in the next major version of FUNSTACK Router.
         </p>
       </section>
 

--- a/packages/docs/src/pages/LearnSsrBasicPage.tsx
+++ b/packages/docs/src/pages/LearnSsrBasicPage.tsx
@@ -116,6 +116,52 @@ function HomePage() {
 
       <section>
         <h3>
+          Deferring Outlet Content with <code>experimentalBrowserBailout</code>
+        </h3>
+        <p>
+          During pathless SSR, an <code>{"<Outlet />"}</code> whose child routes are all path-based
+          renders <code>null</code> on the server, while the same outlet renders content in the
+          browser. React Canary's{" "}
+          <a href="https://react.dev/reference/react-dom/browser">
+            <code>browser()</code>
+          </a>{" "}
+          API offers a cleaner way to express this: the <code>experimentalBrowserBailout</code> prop
+          makes such outlets call <code>use(browser())</code> instead, suspending server rendering
+          at the nearest <code>{"<Suspense>"}</code> boundary and deferring the outlet content to
+          the browser.
+        </p>
+        <CodeBlock language="tsx">{`// Opt in on the Router:
+<Router routes={routes} experimentalBrowserBailout />
+
+// Each outlet that can be unmatched during pathless SSR
+// must be wrapped in a Suspense boundary:
+function AppShell() {
+  return (
+    <div>
+      <header>My App</header>
+      <main>
+        <Suspense fallback={<p>Loading…</p>}>
+          <Outlet />
+        </Suspense>
+      </main>
+    </div>
+  );
+}`}</CodeBlock>
+        <p>
+          The server-rendered HTML then contains the Suspense fallback in place of the outlet, and
+          the browser renders the matched route content there after hydration &mdash; without
+          hydration mismatches.
+        </p>
+        <p>
+          This option requires a React build that exports <code>browser</code> from{" "}
+          <code>react-dom</code> (currently React Canary). On builds without the API, enabling the
+          option throws an error when the Router renders. The <code>experimental</code> prefix will
+          be dropped once <code>browser</code> becomes stable in React.
+        </p>
+      </section>
+
+      <section>
+        <h3>
           The <code>fallback="static"</code> Mode
         </h3>
         <p>

--- a/packages/example-pathless-ssr/package.json
+++ b/packages/example-pathless-ssr/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@funstack/router": "workspace:*",
     "@funstack/static": "^1.2.0",
-    "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react": "19.3.0-canary-eb8feb71-20260814",
+    "react-dom": "19.3.0-canary-eb8feb71-20260814"
   },
   "devDependencies": {
     "@types/react": "^19.2.18",

--- a/packages/example-pathless-ssr/src/ClientApp.tsx
+++ b/packages/example-pathless-ssr/src/ClientApp.tsx
@@ -6,5 +6,8 @@ import "./styles.css";
 export function ClientApp({ routes }: { routes: RouteDefinition[] }) {
   // No ssr prop — during SSR only pathless routes match, rendering the app shell.
   // Path-based content fills in on client hydration.
-  return <Router routes={routes} fallback="static" />;
+  // experimentalBrowserBailout uses React's browser() API to avoid hydration
+  // mismatches by deferring unmatched outlet content to the browser. The
+  // outlet must be wrapped in a <Suspense> boundary (see Layout).
+  return <Router routes={routes} fallback="static" experimentalBrowserBailout />;
 }

--- a/packages/example-pathless-ssr/src/ClientApp.tsx
+++ b/packages/example-pathless-ssr/src/ClientApp.tsx
@@ -6,8 +6,10 @@ import "./styles.css";
 export function ClientApp({ routes }: { routes: RouteDefinition[] }) {
   // No ssr prop — during SSR only pathless routes match, rendering the app shell.
   // Path-based content fills in on client hydration.
-  // experimentalBrowserBailout uses React's browser() API to avoid hydration
-  // mismatches by deferring unmatched outlet content to the browser. The
-  // outlet must be wrapped in a <Suspense> boundary (see Layout).
-  return <Router routes={routes} fallback="static" experimentalBrowserBailout />;
+  // The pathlessSSROutletDeferral feature uses React's browser() API to avoid
+  // hydration mismatches by deferring unmatched outlet content to the browser.
+  // The outlet must be wrapped in a <Suspense> boundary (see Layout).
+  return (
+    <Router routes={routes} fallback="static" features={{ pathlessSSROutletDeferral: true }} />
+  );
 }

--- a/packages/example-pathless-ssr/src/components/Layout.tsx
+++ b/packages/example-pathless-ssr/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { Outlet } from "@funstack/router";
 import { Header } from "./Header.js";
 
@@ -6,7 +7,12 @@ export function Layout() {
     <div className="layout">
       <Header />
       <main className="main">
-        <Outlet />
+        {/* The Suspense boundary is required by experimentalBrowserBailout:
+            during pathless SSR the outlet bails out to the browser, leaving
+            this fallback in the server-rendered HTML. */}
+        <Suspense fallback={<p>Loading…</p>}>
+          <Outlet />
+        </Suspense>
       </main>
       <footer className="footer">
         <p>

--- a/packages/example-pathless-ssr/src/components/Layout.tsx
+++ b/packages/example-pathless-ssr/src/components/Layout.tsx
@@ -7,9 +7,9 @@ export function Layout() {
     <div className="layout">
       <Header />
       <main className="main">
-        {/* The Suspense boundary is required by experimentalBrowserBailout:
-            during pathless SSR the outlet bails out to the browser, leaving
-            this fallback in the server-rendered HTML. */}
+        {/* The Suspense boundary is required by the pathlessSSROutletDeferral
+            feature: during pathless SSR the outlet bails out to the browser,
+            leaving this fallback in the server-rendered HTML. */}
         <Suspense fallback={<p>Loading…</p>}>
           <Outlet />
         </Suspense>

--- a/packages/example-pathless-ssr/vite.config.ts
+++ b/packages/example-pathless-ssr/vite.config.ts
@@ -11,4 +11,10 @@ export default defineConfig({
     react(),
   ],
   base: "/",
+  resolve: {
+    // Ensure all react imports resolve to the same instance.
+    // Without this, the workspace router package may resolve to a different
+    // React version than the one used by this example (React Canary).
+    dedupe: ["react", "react-dom"],
+  },
 });

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -48,6 +48,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "jsdom": "^30.0.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
@@ -57,6 +58,7 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "react": "^19.2.0"
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
   }
 }

--- a/packages/router/src/Outlet.tsx
+++ b/packages/router/src/Outlet.tsx
@@ -7,9 +7,9 @@ import { getBrowserFn } from "./core/browserBailout.js";
  * Renders the matched child route.
  * Used in layout components to specify where child routes should render.
  *
- * When `experimentalBrowserBailout` is enabled on the Router and no child
- * route matches during pathless SSR, calls React's `use(browser())` instead
- * of rendering `null`, suspending server rendering at the nearest
+ * When the `pathlessSSROutletDeferral` feature is enabled on the Router and
+ * no child route matches during pathless SSR, calls React's `use(browser())`
+ * instead of rendering `null`, suspending server rendering at the nearest
  * `<Suspense>` boundary and deferring the content to the browser.
  */
 export function Outlet(): ReactNode {
@@ -23,7 +23,7 @@ export function Outlet(): ReactNode {
   if (
     routeContext.outlet === null &&
     routerContext !== null &&
-    routerContext.experimentalBrowserBailout &&
+    routerContext.features.pathlessSSROutletDeferral &&
     routerContext.url === null
   ) {
     // During pathless SSR, child routes cannot match because there is no URL.

--- a/packages/router/src/Outlet.tsx
+++ b/packages/router/src/Outlet.tsx
@@ -21,6 +21,11 @@ export function Outlet(): ReactNode {
   }
 
   if (
+    // `outlet` is null exactly when this route is the deepest matched route,
+    // i.e. no child route matched below it (see RouteRenderer). Combined with
+    // `url === null` (pathless SSR) below, this identifies an outlet that is
+    // empty only because its path-based children had no URL to match against
+    // — not one that is legitimately empty on the client as well.
     routeContext.outlet === null &&
     routerContext !== null &&
     routerContext.features.pathlessSSROutletDeferral &&

--- a/packages/router/src/Outlet.tsx
+++ b/packages/router/src/Outlet.tsx
@@ -1,15 +1,36 @@
-import { type ReactNode, useContext } from "react";
+import { type ReactNode, use, useContext } from "react";
 import { RouteContext } from "./context/RouteContext.js";
+import { RouterContext } from "./context/RouterContext.js";
+import { getBrowserFn } from "./core/browserBailout.js";
 
 /**
  * Renders the matched child route.
  * Used in layout components to specify where child routes should render.
+ *
+ * When `experimentalBrowserBailout` is enabled on the Router and no child
+ * route matches during pathless SSR, calls React's `use(browser())` instead
+ * of rendering `null`, suspending server rendering at the nearest
+ * `<Suspense>` boundary and deferring the content to the browser.
  */
 export function Outlet(): ReactNode {
   const routeContext = useContext(RouteContext);
+  const routerContext = useContext(RouterContext);
 
   if (!routeContext) {
     return null;
+  }
+
+  if (
+    routeContext.outlet === null &&
+    routerContext !== null &&
+    routerContext.experimentalBrowserBailout &&
+    routerContext.url === null
+  ) {
+    // During pathless SSR, child routes cannot match because there is no URL.
+    // use(browser()) suspends server rendering at the nearest <Suspense>
+    // boundary, deferring the outlet content to the browser. In the browser,
+    // use(browser()) returns undefined and rendering continues.
+    use(getBrowserFn()("Route not matched during pathless SSR"));
   }
 
   return routeContext.outlet;

--- a/packages/router/src/Router/index.tsx
+++ b/packages/router/src/Router/index.tsx
@@ -127,12 +127,25 @@ export type RouterProps = {
    */
   experimentalTransitionTypes?: GetTransitionTypes;
   /**
-   * **Experimental.** Use React's `browser()` API to defer unmatched outlet
-   * content to the browser during pathless SSR.
+   * Opt-in feature flags that change the Router's behavior.
+   *
+   * Each flag is opt-in in the current major version; see the documentation
+   * of the individual flags on {@link RouterFeatures} for details.
+   */
+  features?: RouterFeatures;
+};
+
+/**
+ * Opt-in feature flags for the Router, passed via the `features` prop.
+ */
+export type RouterFeatures = {
+  /**
+   * Use React's `browser()` API to defer unmatched outlet content to the
+   * browser during pathless SSR.
    *
    * During pathless SSR (no `ssr` prop), path-based child routes cannot match
    * because no URL is available, so `<Outlet />` renders `null` on the server
-   * while the same outlet renders content in the browser. When this option is
+   * while the same outlet renders content in the browser. When this flag is
    * enabled, `<Outlet />` instead calls `use(browser())` in that situation,
    * suspending server rendering at the nearest `<Suspense>` boundary and
    * deferring the outlet content to the browser — avoiding hydration
@@ -140,15 +153,15 @@ export type RouterProps = {
    * or the server render fails.
    *
    * Requires a React build that exports `browser` from react-dom (currently
-   * React Canary). On builds that don't expose the API, enabling this option
+   * React Canary). On builds that don't expose the API, enabling this flag
    * throws an error when the Router renders.
    *
-   * The `experimental` prefix will be dropped once `browser` becomes stable
-   * in React.
+   * This behavior will become the default in the next major version of
+   * FUNSTACK Router.
    *
    * @default false
    */
-  experimentalBrowserBailout?: boolean;
+  pathlessSSROutletDeferral?: boolean;
 };
 
 export function Router({
@@ -158,15 +171,23 @@ export function Router({
   ssr,
   trailingSlash,
   experimentalTransitionTypes,
-  experimentalBrowserBailout = false,
+  features,
 }: RouterProps): ReactNode {
   const routes = internalRoutes(inputRoutes);
 
-  if (experimentalBrowserBailout) {
+  const pathlessSSROutletDeferral = features?.pathlessSSROutletDeferral ?? false;
+
+  if (pathlessSSROutletDeferral) {
     // Fail fast (on both server and client) when the host React build
     // doesn't support the browser() API.
     getBrowserFn();
   }
+
+  // Feature flags with defaults applied, for consumption via RouterContext
+  const resolvedFeatures = useMemo(
+    () => ({ pathlessSSROutletDeferral }),
+    [pathlessSSROutletDeferral],
+  );
 
   // Create adapter once based on browser capabilities and fallback setting
   const adapter = useMemo(() => createAdapter(fallback), [fallback]);
@@ -421,7 +442,7 @@ export function Router({
       isPending,
       navigateAsync,
       updateCurrentEntryState,
-      experimentalBrowserBailout,
+      features: resolvedFeatures,
     }),
     [
       locationState,
@@ -432,7 +453,7 @@ export function Router({
       isPending,
       navigateAsync,
       updateCurrentEntryState,
-      experimentalBrowserBailout,
+      resolvedFeatures,
     ],
   );
 

--- a/packages/router/src/Router/index.tsx
+++ b/packages/router/src/Router/index.tsx
@@ -22,6 +22,7 @@ import {
   internalRoutes,
 } from "../types.js";
 import { addTransitionType } from "../core/addTransitionType.js";
+import { getBrowserFn } from "../core/browserBailout.js";
 import { matchRoutes } from "../core/matchRoutes.js";
 import { createAdapter } from "../core/createAdapter.js";
 import { executeLoaders, createLoaderRequest } from "../core/loaderCache.js";
@@ -125,6 +126,29 @@ export type RouterProps = {
    * @default () => ["navigation"]
    */
   experimentalTransitionTypes?: GetTransitionTypes;
+  /**
+   * **Experimental.** Use React's `browser()` API to defer unmatched outlet
+   * content to the browser during pathless SSR.
+   *
+   * During pathless SSR (no `ssr` prop), path-based child routes cannot match
+   * because no URL is available, so `<Outlet />` renders `null` on the server
+   * while the same outlet renders content in the browser. When this option is
+   * enabled, `<Outlet />` instead calls `use(browser())` in that situation,
+   * suspending server rendering at the nearest `<Suspense>` boundary and
+   * deferring the outlet content to the browser — avoiding hydration
+   * mismatches. Each such outlet must be wrapped in a `<Suspense>` boundary,
+   * or the server render fails.
+   *
+   * Requires a React build that exports `browser` from react-dom (currently
+   * React Canary). On builds that don't expose the API, enabling this option
+   * throws an error when the Router renders.
+   *
+   * The `experimental` prefix will be dropped once `browser` becomes stable
+   * in React.
+   *
+   * @default false
+   */
+  experimentalBrowserBailout?: boolean;
 };
 
 export function Router({
@@ -134,8 +158,15 @@ export function Router({
   ssr,
   trailingSlash,
   experimentalTransitionTypes,
+  experimentalBrowserBailout = false,
 }: RouterProps): ReactNode {
   const routes = internalRoutes(inputRoutes);
+
+  if (experimentalBrowserBailout) {
+    // Fail fast (on both server and client) when the host React build
+    // doesn't support the browser() API.
+    getBrowserFn();
+  }
 
   // Create adapter once based on browser capabilities and fallback setting
   const adapter = useMemo(() => createAdapter(fallback), [fallback]);
@@ -390,6 +421,7 @@ export function Router({
       isPending,
       navigateAsync,
       updateCurrentEntryState,
+      experimentalBrowserBailout,
     }),
     [
       locationState,
@@ -400,6 +432,7 @@ export function Router({
       isPending,
       navigateAsync,
       updateCurrentEntryState,
+      experimentalBrowserBailout,
     ],
   );
 

--- a/packages/router/src/__tests__/browserBailout.test.tsx
+++ b/packages/router/src/__tests__/browserBailout.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Suspense } from "react";
+import { renderToString } from "react-dom/server";
+import { render, screen } from "@testing-library/react";
+import { Router } from "../Router/index.js";
+import { Outlet } from "../Outlet.js";
+import { route, type RouteDefinition } from "../route.js";
+import { setupNavigationMock, cleanupNavigationMock } from "./setup.js";
+
+// Simulate a React build that supports the browser() API (React Canary).
+// The mocked browser() returns a never-resolving thenable so that use()
+// suspends during server rendering, leaving the nearest <Suspense> fallback
+// in place — approximating the canary behavior of use(browser()).
+const { browserMock } = vi.hoisted(() => {
+  return {
+    browserMock: vi.fn((_reason?: unknown): PromiseLike<undefined> => ({
+      then() {
+        return this as PromiseLike<never>;
+      },
+    })),
+  };
+});
+
+vi.mock("react-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-dom")>();
+  return { ...actual, browser: browserMock };
+});
+
+function makeRoutes(): RouteDefinition[] {
+  return [
+    route({
+      // Pathless root route: acts as the app shell during pathless SSR.
+      component: () => (
+        <div>
+          <span>shell</span>
+          <Suspense fallback={<span>suspense-fallback</span>}>
+            <Outlet />
+          </Suspense>
+        </div>
+      ),
+      children: [route({ path: "/", component: () => <span>home</span> })],
+    }),
+  ];
+}
+
+describe("experimentalBrowserBailout (browser() supported)", () => {
+  beforeEach(() => {
+    browserMock.mockClear();
+  });
+
+  describe("pathless SSR", () => {
+    it("defers unmatched outlet content to the nearest Suspense boundary", () => {
+      const html = renderToString(<Router routes={makeRoutes()} experimentalBrowserBailout />);
+
+      expect(html).toContain("shell");
+      expect(html).toContain("suspense-fallback");
+      expect(html).not.toContain("<span>home</span>");
+      expect(browserMock).toHaveBeenCalledWith("Route not matched during pathless SSR");
+    });
+
+    it("renders unmatched outlets as null when not opted in", () => {
+      const html = renderToString(<Router routes={makeRoutes()} />);
+
+      expect(html).toContain("shell");
+      expect(html).not.toContain("suspense-fallback");
+      expect(html).not.toContain("home");
+      expect(browserMock).not.toHaveBeenCalled();
+    });
+
+    it("does not bail out when a pathless child route matches", () => {
+      const routes = [
+        route({
+          component: () => (
+            <div>
+              <span>shell</span>
+              <Suspense fallback={<span>suspense-fallback</span>}>
+                <Outlet />
+              </Suspense>
+            </div>
+          ),
+          // Pathless child: matches even during pathless SSR.
+          children: [route({ component: () => <span>pathless-child</span> })],
+        }),
+      ];
+
+      const html = renderToString(<Router routes={routes} experimentalBrowserBailout />);
+
+      expect(html).toContain("pathless-child");
+      expect(html).not.toContain("suspense-fallback");
+      expect(browserMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("SSR with ssr.path", () => {
+    it("does not bail out because the URL is available", () => {
+      const html = renderToString(
+        <Router routes={makeRoutes()} ssr={{ path: "/" }} experimentalBrowserBailout />,
+      );
+
+      expect(html).toContain("home");
+      expect(html).not.toContain("suspense-fallback");
+      expect(browserMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("client-side rendering", () => {
+    beforeEach(() => {
+      setupNavigationMock("http://localhost/");
+    });
+
+    afterEach(() => {
+      cleanupNavigationMock();
+    });
+
+    it("does not bail out because the URL is available", () => {
+      render(<Router routes={makeRoutes()} experimentalBrowserBailout />);
+
+      expect(screen.getByText("home")).toBeInTheDocument();
+      expect(browserMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/router/src/__tests__/browserBailout.test.tsx
+++ b/packages/router/src/__tests__/browserBailout.test.tsx
@@ -43,14 +43,16 @@ function makeRoutes(): RouteDefinition[] {
   ];
 }
 
-describe("experimentalBrowserBailout (browser() supported)", () => {
+describe("pathlessSSROutletDeferral (browser() supported)", () => {
   beforeEach(() => {
     browserMock.mockClear();
   });
 
   describe("pathless SSR", () => {
     it("defers unmatched outlet content to the nearest Suspense boundary", () => {
-      const html = renderToString(<Router routes={makeRoutes()} experimentalBrowserBailout />);
+      const html = renderToString(
+        <Router routes={makeRoutes()} features={{ pathlessSSROutletDeferral: true }} />,
+      );
 
       expect(html).toContain("shell");
       expect(html).toContain("suspense-fallback");
@@ -83,7 +85,9 @@ describe("experimentalBrowserBailout (browser() supported)", () => {
         }),
       ];
 
-      const html = renderToString(<Router routes={routes} experimentalBrowserBailout />);
+      const html = renderToString(
+        <Router routes={routes} features={{ pathlessSSROutletDeferral: true }} />,
+      );
 
       expect(html).toContain("pathless-child");
       expect(html).not.toContain("suspense-fallback");
@@ -94,7 +98,11 @@ describe("experimentalBrowserBailout (browser() supported)", () => {
   describe("SSR with ssr.path", () => {
     it("does not bail out because the URL is available", () => {
       const html = renderToString(
-        <Router routes={makeRoutes()} ssr={{ path: "/" }} experimentalBrowserBailout />,
+        <Router
+          routes={makeRoutes()}
+          ssr={{ path: "/" }}
+          features={{ pathlessSSROutletDeferral: true }}
+        />,
       );
 
       expect(html).toContain("home");
@@ -113,7 +121,7 @@ describe("experimentalBrowserBailout (browser() supported)", () => {
     });
 
     it("does not bail out because the URL is available", () => {
-      render(<Router routes={makeRoutes()} experimentalBrowserBailout />);
+      render(<Router routes={makeRoutes()} features={{ pathlessSSROutletDeferral: true }} />);
 
       expect(screen.getByText("home")).toBeInTheDocument();
       expect(browserMock).not.toHaveBeenCalled();

--- a/packages/router/src/__tests__/browserBailout.unsupported.test.tsx
+++ b/packages/router/src/__tests__/browserBailout.unsupported.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { renderToString } from "react-dom/server";
+import { Router } from "../Router/index.js";
+import { route, type RouteDefinition } from "../route.js";
+
+// These tests run against the real react-dom installed in this repo (stable),
+// which does not expose the browser() API.
+
+function makeRoutes(): RouteDefinition[] {
+  return [route({ component: () => <div>shell</div> })];
+}
+
+describe("experimentalBrowserBailout (browser() unsupported)", () => {
+  it("throws when opted in on a React build without the browser() API", () => {
+    expect(() =>
+      renderToString(<Router routes={makeRoutes()} experimentalBrowserBailout />),
+    ).toThrowError(/experimentalBrowserBailout.*browser\(\)/s);
+  });
+
+  it("does not throw when not opted in", () => {
+    const html = renderToString(<Router routes={makeRoutes()} />);
+    expect(html).toContain("shell");
+  });
+});

--- a/packages/router/src/__tests__/browserBailout.unsupported.test.tsx
+++ b/packages/router/src/__tests__/browserBailout.unsupported.test.tsx
@@ -10,11 +10,13 @@ function makeRoutes(): RouteDefinition[] {
   return [route({ component: () => <div>shell</div> })];
 }
 
-describe("experimentalBrowserBailout (browser() unsupported)", () => {
+describe("pathlessSSROutletDeferral (browser() unsupported)", () => {
   it("throws when opted in on a React build without the browser() API", () => {
     expect(() =>
-      renderToString(<Router routes={makeRoutes()} experimentalBrowserBailout />),
-    ).toThrowError(/experimentalBrowserBailout.*browser\(\)/s);
+      renderToString(
+        <Router routes={makeRoutes()} features={{ pathlessSSROutletDeferral: true }} />,
+      ),
+    ).toThrowError(/pathlessSSROutletDeferral.*browser\(\)/s);
   });
 
   it("does not throw when not opted in", () => {

--- a/packages/router/src/context/RouterContext.ts
+++ b/packages/router/src/context/RouterContext.ts
@@ -24,6 +24,11 @@ export type RouterContextValue = {
   navigateAsync: (to: string, options?: NavigateOptions) => Promise<void>;
   /** Update current entry's state without navigation */
   updateCurrentEntryState: (state: unknown) => void;
+  /**
+   * Whether to use React's `browser()` API to defer to the browser content
+   * that cannot be rendered during pathless SSR.
+   */
+  experimentalBrowserBailout: boolean;
 };
 
 export const RouterContext = createContext<RouterContextValue | null>(null);

--- a/packages/router/src/context/RouterContext.ts
+++ b/packages/router/src/context/RouterContext.ts
@@ -1,5 +1,7 @@
 import { createContext } from "react";
 import type { NavigateOptions } from "../types.js";
+// Type-only import; erased at runtime, so no circular dependency.
+import type { RouterFeatures } from "../Router/index.js";
 
 export type RouterContextValue = {
   /**
@@ -24,11 +26,8 @@ export type RouterContextValue = {
   navigateAsync: (to: string, options?: NavigateOptions) => Promise<void>;
   /** Update current entry's state without navigation */
   updateCurrentEntryState: (state: unknown) => void;
-  /**
-   * Whether to use React's `browser()` API to defer to the browser content
-   * that cannot be rendered during pathless SSR.
-   */
-  experimentalBrowserBailout: boolean;
+  /** Feature flags from the Router's `features` prop, with defaults applied */
+  features: Required<RouterFeatures>;
 };
 
 export const RouterContext = createContext<RouterContextValue | null>(null);

--- a/packages/router/src/core/browserBailout.ts
+++ b/packages/router/src/core/browserBailout.ts
@@ -8,8 +8,10 @@ import * as ReactDOM from "react-dom";
  */
 type BrowserFn = (reason?: string | (() => unknown)) => PromiseLike<undefined>;
 
+// The API shipped directly under the `browser` name in both the Canary and
+// Experimental channels — there is no `unstable_`-prefixed variant.
 const reactDOMExports = ReactDOM as unknown as Record<string, unknown>;
-const candidate = reactDOMExports.browser ?? reactDOMExports.unstable_browser;
+const candidate = reactDOMExports.browser;
 
 /**
  * The `browser` function from react-dom, or `null` when the host React build

--- a/packages/router/src/core/browserBailout.ts
+++ b/packages/router/src/core/browserBailout.ts
@@ -1,0 +1,35 @@
+import * as ReactDOM from "react-dom";
+
+/**
+ * React's `browser()` API (react-dom). Returns an opaque value that, when
+ * passed to `use()`, suspends server rendering at the nearest `<Suspense>`
+ * boundary and resumes rendering in the browser (where `use()` returns
+ * `undefined`).
+ */
+type BrowserFn = (reason?: string | (() => unknown)) => PromiseLike<undefined>;
+
+const reactDOMExports = ReactDOM as unknown as Record<string, unknown>;
+const candidate = reactDOMExports.browser ?? reactDOMExports.unstable_browser;
+
+/**
+ * The `browser` function from react-dom, or `null` when the host React build
+ * doesn't expose the API. `browser` is currently available only in React
+ * Canary.
+ */
+const browserFn: BrowserFn | null =
+  typeof candidate === "function" ? (candidate as BrowserFn) : null;
+
+/**
+ * Returns React's `browser()` function, or throws when the host React build
+ * doesn't support it.
+ */
+export function getBrowserFn(): BrowserFn {
+  if (browserFn === null) {
+    throw new Error(
+      "The `experimentalBrowserBailout` option requires a React build that " +
+        "supports the `browser()` API from react-dom (currently React Canary). " +
+        "Upgrade react and react-dom, or remove the `experimentalBrowserBailout` prop.",
+    );
+  }
+  return browserFn;
+}

--- a/packages/router/src/core/browserBailout.ts
+++ b/packages/router/src/core/browserBailout.ts
@@ -8,8 +8,6 @@ import * as ReactDOM from "react-dom";
  */
 type BrowserFn = (reason?: string | (() => unknown)) => PromiseLike<undefined>;
 
-// The API shipped directly under the `browser` name in both the Canary and
-// Experimental channels — there is no `unstable_`-prefixed variant.
 const reactDOMExports = ReactDOM as unknown as Record<string, unknown>;
 const candidate = reactDOMExports.browser;
 

--- a/packages/router/src/core/browserBailout.ts
+++ b/packages/router/src/core/browserBailout.ts
@@ -26,9 +26,10 @@ const browserFn: BrowserFn | null =
 export function getBrowserFn(): BrowserFn {
   if (browserFn === null) {
     throw new Error(
-      "The `experimentalBrowserBailout` option requires a React build that " +
+      "The `pathlessSSROutletDeferral` feature requires a React build that " +
         "supports the `browser()` API from react-dom (currently React Canary). " +
-        "Upgrade react and react-dom, or remove the `experimentalBrowserBailout` prop.",
+        "Upgrade react and react-dom, or remove `pathlessSSROutletDeferral` " +
+        "from the Router's `features` prop.",
     );
   }
   return browserFn;

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -3,7 +3,7 @@
 // FUNSTACK Router - A modern React router based on the Navigation API
 
 // Components
-export { Router, type RouterProps, type SSRConfig } from "./Router/index.js";
+export { Router, type RouterProps, type RouterFeatures, type SSRConfig } from "./Router/index.js";
 export { Outlet } from "./Outlet.js";
 
 // Hooks

--- a/packages/router/tsdown.config.ts
+++ b/packages/router/tsdown.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   format: ["esm"],
   dts: true,
   clean: true,
-  external: ["react", "@funstack/skill-installer"],
+  external: ["react", "react-dom", "@funstack/skill-installer"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,13 +90,13 @@ importers:
         version: link:../router
       '@funstack/static':
         specifier: ^1.2.0
-        version: 1.2.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))
+        version: 1.2.0(react-dom@19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814))(react@19.3.0-canary-eb8feb71-20260814)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))
       react:
-        specifier: ^19.2.8
-        version: 19.2.8
+        specifier: 19.3.0-canary-eb8feb71-20260814
+        version: 19.3.0-canary-eb8feb71-20260814
       react-dom:
-        specifier: ^19.2.8
-        version: 19.2.8(react@19.2.8)
+        specifier: 19.3.0-canary-eb8feb71-20260814
+        version: 19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814)
     devDependencies:
       '@types/react':
         specifier: ^19.2.18
@@ -163,6 +163,9 @@ importers:
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.18)
       jsdom:
         specifier: ^30.0.1
         version: 30.0.1
@@ -538,105 +541,89 @@ packages:
     resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.1':
     resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.1':
     resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.1':
     resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.1':
     resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.1':
     resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
     resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.1':
     resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.2':
     resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.2':
     resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.2':
     resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.2':
     resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.2':
     resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.2':
     resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.2':
     resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.2':
     resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.35.2':
     resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
@@ -744,56 +731,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.63.0':
     resolution: {integrity: sha512-alPmbOuWXFXiSo+lOtv6X71C7SYMEDW2WVvywOvf9BwKgEhSNGhMTLeFVSjKUMCamcjbbgVdsWF8GN1uy8xshg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.63.0':
     resolution: {integrity: sha512-BdzCPvolJc4AWZ+YMzgUDJcDzbQWrFjYuqBHoNHNqP1aCaluQRJNs4k3vNU5IG7vTpjf9zeD73D7MFM1TecZpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.63.0':
     resolution: {integrity: sha512-7sIgfLzqtNKSkMGsGVyRpHwpjNezRg2XONvUOheFZs95TSZpM0JAuPpA8KrQFsWc4wPU95roX2O69JgH8igOgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.63.0':
     resolution: {integrity: sha512-9Tcg0y0WcVa6Mm9AgcgFMseDS+VkFJZpKZ8We9SpDY4gg5jewSwln+0sO04QLcTS1BtfDl9MwR+NfID8L7PUTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.63.0':
     resolution: {integrity: sha512-qWKC1pEOpx1qYhXaugPhHUeXwSfqEOk2wJH2LqVXGPV5iQYfdAZdt+d2XDiX4DTSWA2QDMUcFB+wEORh3Xn/sA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.63.0':
     resolution: {integrity: sha512-S9wXYOiGSqYGS4Fx/TFsY+xDd/7dE5s+rUgbA4TsHiVF9e8J3ZcKmP7dsP/7iqLI9Wz7Ic7TzEr3mdthRCTdrA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.63.0':
     resolution: {integrity: sha512-5eGyTJuMZNwBSHCivXt8Yuta6GeTYksOPXRk2MIhajiyFGQx7bjaHIwY+ZusAoFHhT157A9x6sktLjYo9D5oMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.63.0':
     resolution: {integrity: sha512-Rz7hx+Dv3DoW/S6pwVAyjfFXp7/trdQ1zg+vNmsdsdDNlUccugp4XNqambSuEAeP0DaG9k72AtNyfDXCEg0AGw==}
@@ -866,56 +845,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.78.0':
     resolution: {integrity: sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.78.0':
     resolution: {integrity: sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.78.0':
     resolution: {integrity: sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.78.0':
     resolution: {integrity: sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.78.0':
     resolution: {integrity: sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.78.0':
     resolution: {integrity: sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.78.0':
     resolution: {integrity: sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.78.0':
     resolution: {integrity: sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg==}
@@ -1048,126 +1019,108 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.0':
     resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.4':
     resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.2.0':
     resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.2.4':
     resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.4':
     resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.0':
     resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.4':
     resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.0':
     resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.4':
     resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.0':
     resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.4':
     resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -1572,37 +1525,31 @@ packages:
     resolution: {integrity: sha512-Ur3Awo45Sc5/Fglr8WN5XIf4IwAsq8wLd917Du8ow6mStxsBTHqFiH+tT7d5jV0FqcJnwy8EHVczmgde0zTo1A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm-musl@0.8.0':
     resolution: {integrity: sha512-FIy7Ttx8oeUCd/8Y6IjnOsu+lRc6En+V/H67BlVphOeCySZAo5LU8VWrb4tv0DvjaSOzdm3DmdmRzmzN7NCqWQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-linux-arm64-gnu@0.8.0':
     resolution: {integrity: sha512-s+25wl1TLvf+7LzasPEi1RR1sDfVAU0i1QH601mn3vj+HudFYBYNZtUBKFaZvl645QR6vcaDaGHnOaMZhBR3ig==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-arm64-musl@0.8.0':
     resolution: {integrity: sha512-pRha3Cjm4AnA5wEuhpg+8XXoGfwz5X61/9a/VNxeau47+kH6xjJspkEloIy/HbHgUnvVRqVHoEHczdGZT2J9NA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-linux-x64-gnu@0.8.0':
     resolution: {integrity: sha512-GySXmiw5Dw99Ba3GMV2ExQVckihuangnrIpSJagPx8RFUNtwfmzpr2ibf8k31eEAE4YUofV7mEfJN5tN6+POnQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-codegen/binding-linux-x64-musl@0.8.0':
     resolution: {integrity: sha512-8YFfcPZz44v8YyekWVKkNz/cD4t6DW62/dr03OVtMfwUtHfmo/8wpby0JKMleAOXbgWItSGw81LtwqM4I9oS0A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-codegen/binding-win32-arm64@0.8.0':
     resolution: {integrity: sha512-YhENbgkuzjsil+zDNV35oU3PQMDg2RXh8BPt915WCNAbIIHcqgYupHJF3564206+DbPkZtcDvcoa34Wb5B8tbQ==}
@@ -1633,37 +1580,31 @@ packages:
     resolution: {integrity: sha512-+cuJWUK13lwce721XGRjz7izSr2Q1U0RlHkDzdkohWpRWlttTqRdxNnaW13nDc47GBDrNsXMHx+KLcebeOeeGg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm-musl@0.8.0':
     resolution: {integrity: sha512-rOVPRqt9cm1YP/wPV+yyZh0FYr6UR/wm/BXslvLuge0LDewVvDrm/AxcDrwWuPAu61Nzdg2rMVfcNnrplCbC1w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-linux-arm64-gnu@0.8.0':
     resolution: {integrity: sha512-pAoIozKr6E+ptpaQz4CZv1O7cay2f4m7kbd+DSQug5MKdUBTZZ18GdWSPvq0fwQYraH9hZlyLqrMaeP5W/ncrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-arm64-musl@0.8.0':
     resolution: {integrity: sha512-JCAg50ahXuYlrsIi1jmymX9X/9B0JYBRroAHnYttN44tAvCo1PFqukHrw1up6HvEOoLA0OjlM0Zwh60u3Gc/Zg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-linux-x64-gnu@0.8.0':
     resolution: {integrity: sha512-tEeVQ14etp7lpUqXzq+X5AlQzFH+m3TVDiCKIq17zxnxJ117DOVvoveWSkSMt/lj68z48SvZUMHe7xLvqtO1lg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@yuku-parser/binding-linux-x64-musl@0.8.0':
     resolution: {integrity: sha512-+UGRYnF37nnbZNMsMjSGDXKUTIxYUmbbk3Lzib88sLK7kg2y80vjchYYoYsDUK9kAgqPWyA9hKGURHy/Kk9Few==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@yuku-parser/binding-win32-arm64@0.8.0':
     resolution: {integrity: sha512-l+7Va9/sX1ccRjzjJj6MR0arKsvHB5b419+pKbwzn+/18A/xfccWqmxXrn0C0NyVLlbEb3AV9Is+AbF72O85yA==}
@@ -1908,28 +1849,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -2071,6 +2008,11 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
+  react-dom@19.3.0-canary-eb8feb71-20260814:
+    resolution: {integrity: sha512-sURKF6v4XliFLgl9+lT3S9zM9EEqJFDzYwE7+BtHdUesovByKQbM9dm4WqGr/b3kiTq6jw7ASIYG10j/t2pbbQ==}
+    peerDependencies:
+      react: 19.3.0-canary-eb8feb71-20260814
+
   react-error-boundary@6.1.1:
     resolution: {integrity: sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w==}
     peerDependencies:
@@ -2081,6 +2023,10 @@ packages:
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.3.0-canary-eb8feb71-20260814:
+    resolution: {integrity: sha512-4CF6VVbInQ54749LzFJ6POm1SREXQmNZ6yFjTq67yCL3NrYlK+aO6nzO3i1Fe7szu/fXUr3NRzitdHj+l/O5EQ==}
     engines: {node: '>=0.10.0'}
 
   redent@3.0.0:
@@ -2146,6 +2092,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  scheduler@0.28.0-canary-eb8feb71-20260814:
+    resolution: {integrity: sha512-TjXQVWDPcNnqesHvbi5WB587WPFr8to90JVhOIO0szb0GFgg0fF0PPJCWoxi0poyxJ98OThXb22akDHfZyXG6A==}
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -2726,6 +2675,19 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-error-boundary: 6.1.1(react@19.2.8)
+      rsc-html-stream: 0.0.7
+      srvx: 0.11.15
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)
+    transitivePeerDependencies:
+      - react-server-dom-webpack
+
+  '@funstack/static@1.2.0(react-dom@19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814))(react@19.3.0-canary-eb8feb71-20260814)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))':
+    dependencies:
+      '@funstack/skill-installer': 1.0.0
+      '@vitejs/plugin-rsc': 0.5.23(react-dom@19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814))(react@19.3.0-canary-eb8feb71-20260814)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))
+      react: 19.3.0-canary-eb8feb71-20260814
+      react-dom: 19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814)
+      react-error-boundary: 6.1.1(react@19.3.0-canary-eb8feb71-20260814)
       rsc-html-stream: 0.0.7
       srvx: 0.11.15
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)
@@ -3361,6 +3323,20 @@ snapshots:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))
 
+  '@vitejs/plugin-rsc@0.5.23(react-dom@19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814))(react@19.3.0-canary-eb8feb71-20260814)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      es-module-lexer: 2.0.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      react: 19.3.0-canary-eb8feb71-20260814
+      react-dom: 19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814)
+      srvx: 0.11.15
+      strip-literal: 3.1.0
+      turbo-stream: 3.2.0
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)
+      vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1))
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3859,13 +3835,24 @@ snapshots:
       react: 19.2.8
       scheduler: 0.27.0
 
+  react-dom@19.3.0-canary-eb8feb71-20260814(react@19.3.0-canary-eb8feb71-20260814):
+    dependencies:
+      react: 19.3.0-canary-eb8feb71-20260814
+      scheduler: 0.28.0-canary-eb8feb71-20260814
+
   react-error-boundary@6.1.1(react@19.2.8):
     dependencies:
       react: 19.2.8
 
+  react-error-boundary@6.1.1(react@19.3.0-canary-eb8feb71-20260814):
+    dependencies:
+      react: 19.3.0-canary-eb8feb71-20260814
+
   react-is@17.0.2: {}
 
   react@19.2.8: {}
+
+  react@19.3.0-canary-eb8feb71-20260814: {}
 
   redent@3.0.0:
     dependencies:
@@ -3970,6 +3957,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  scheduler@0.28.0-canary-eb8feb71-20260814: {}
 
   semver@7.8.5: {}
 


### PR DESCRIPTION
## Summary

Resurrects the pathless-SSR outlet deferral feature that was previously built on React's postpone API (#162, reverted in #175 when React decided not to stabilize postpone), now backed by the [`browser()` API](https://react.dev/reference/react-dom/browser) available in React Canary.

The opt-in is expressed through a new general-purpose `features` prop on `<Router>`:

```tsx
<Router routes={routes} features={{ pathlessSSROutletDeferral: true }} />
```

## What it does

When the `pathlessSSROutletDeferral` feature is enabled, an `<Outlet />` whose child routes cannot match during pathless SSR (no URL available) calls `use(browser())` instead of rendering `null`. Server rendering suspends at the nearest `<Suspense>` boundary, leaving the fallback in the server-rendered HTML, and the outlet content renders in the browser — avoiding hydration mismatches between the server-rendered shell and the hydrated app.

- **Opt-in feature flag**: defaults to `false`; behavior is unchanged unless the flag is set. Documented (in JSDoc and on the docs site) to become the default behavior in the next major version.
- **Throws on unsupported React**: when the flag is enabled but the installed `react-dom` does not export `browser()` (i.e. anything below the current Canary), the Router throws a descriptive error at render, on both server and client.

## Changes

- `packages/router/src/Router/index.tsx`: new `features` prop and exported `RouterFeatures` type carrying the `pathlessSSROutletDeferral` flag (JSDoc'd, default `false`, noted as the next-major default); fails fast when enabled without support; threads the resolved flags through `RouterContext`.
- `packages/router/src/core/browserBailout.ts` (new): feature-detects the `browser` export on the `react-dom` namespace and exposes `getBrowserFn()`, which throws a descriptive error when the API is missing.
- `packages/router/src/Outlet.tsx`: when the outlet is empty (`outlet === null`, i.e. this route is the deepest matched route — no child route matched below it), the flag is on, and no URL is available (pathless SSR), calls `use(browser("Route not matched during pathless SSR"))`.
- `packages/router/package.json` / `tsdown.config.ts`: the router now imports `react-dom`, so it is declared as a peer dependency (`^19.2.0`) and marked external in the build; `@types/react-dom` added to devDependencies.
- `packages/example-pathless-ssr`: opts in to the feature — React pinned to `19.3.0-canary-eb8feb71-20260814` (the current canary, which ships `browser()`), outlet wrapped in `<Suspense>`, and `resolve.dedupe` restored in the Vite config so the workspace router resolves to the same React instance.
- `packages/docs`: new "Deferring Outlet Content with `pathlessSSROutletDeferral`" section on the *How SSR Works* page (including the next-major note), and a `features` row in the `<Router>` props table.

## Tests

- `browserBailout.test.tsx`: mocks `react-dom` to provide a `browser()` implementation and verifies the feature defers unmatched outlet content to the Suspense fallback during pathless SSR, calls `browser()` with the reason, and does not fire when not opted in, when a pathless child matches, when `ssr.path` is provided, or during client rendering.
- `browserBailout.unsupported.test.tsx`: runs against the real (stable) `react-dom` and verifies the opt-in throws while the default does not.

All 336 router tests pass, along with monorepo build, typecheck, lint, and format checks (on Node 24, matching CI). The pathless-SSR example was additionally verified end-to-end: the prerendered HTML contains the Suspense fallback in place of the outlet (`<!--$!--><template data-dgst=""></template><p>Loading…</p>`), and loading the built site in Chromium hydrates without errors and fills in the routed content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8sKrj2i5mR5PQCoFwx7ti