### PR TITLE
feat(docs): improve search engine visibility of the docs site

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -17,6 +17,7 @@
     "shiki": "^4.4.3"
   },
   "devDependencies": {
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",

--- a/packages/docs/public/robots.txt
+++ b/packages/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://router.funstack.work/sitemap.xml

--- a/packages/docs/src/App.tsx
+++ b/packages/docs/src/App.tsx
@@ -1,4 +1,5 @@
-import { lazy } from "react";
+import { lazy, type ReactElement, type ReactNode } from "react";
+import { PageMeta } from "./pageMeta.js";
 import { route } from "@funstack/router/server";
 import { defer } from "@funstack/static/server";
 import { Layout } from "./components/Layout.js";
@@ -115,6 +116,15 @@ const NotFoundPage = lazy(() =>
   })),
 );
 
+function withMeta(path: string, node: ReactNode): ReactElement {
+  return (
+    <>
+      <PageMeta path={path} />
+      {node}
+    </>
+  );
+}
+
 export const routes = [
   route({
     component: (
@@ -129,11 +139,11 @@ export const routes = [
         children: [
           route({
             path: "/",
-            component: defer(<HomePage />, { name: "HomePage" }),
+            component: defer(withMeta("/", <HomePage />), { name: "HomePage" }),
           }),
           route({
             path: "/getting-started",
-            component: defer(<GettingStartedPage />, {
+            component: defer(withMeta("/getting-started", <GettingStartedPage />), {
               name: "GettingStartedPage",
             }),
           }),
@@ -143,25 +153,25 @@ export const routes = [
             children: [
               route({
                 path: "/",
-                component: defer(<LearnIndexPage />, {
+                component: defer(withMeta("/learn", <LearnIndexPage />), {
                   name: "LearnIndexPage",
                 }),
               }),
               route({
                 path: "/navigation-api",
-                component: defer(<LearnNavigationApiPage />, {
+                component: defer(withMeta("/learn/navigation-api", <LearnNavigationApiPage />), {
                   name: "LearnNavigationApiPage",
                 }),
               }),
               route({
                 path: "/nested-routes",
-                component: defer(<LearnNestedRoutesPage />, {
+                component: defer(withMeta("/learn/nested-routes", <LearnNestedRoutesPage />), {
                   name: "LearnNestedRoutesPage",
                 }),
               }),
               route({
                 path: "/type-safety",
-                component: defer(<LearnTypeSafetyPage />, {
+                component: defer(withMeta("/learn/type-safety", <LearnTypeSafetyPage />), {
                   name: "LearnTypeSafetyPage",
                 }),
               }),
@@ -171,21 +181,27 @@ export const routes = [
                 children: [
                   route({
                     path: "/",
-                    component: defer(<LearnSsrBasicPage />, {
+                    component: defer(withMeta("/learn/ssr", <LearnSsrBasicPage />), {
                       name: "LearnSsrBasicPage",
                     }),
                   }),
                   route({
                     path: "/static-site-generation",
-                    component: defer(<LearnSsgPage />, {
-                      name: "LearnSsgPage",
-                    }),
+                    component: defer(
+                      withMeta("/learn/ssr/static-site-generation", <LearnSsgPage />),
+                      {
+                        name: "LearnSsgPage",
+                      },
+                    ),
                   }),
                   route({
                     path: "/with-loaders",
-                    component: defer(<LearnSsrWithLoadersPage />, {
-                      name: "LearnSsrWithLoadersPage",
-                    }),
+                    component: defer(
+                      withMeta("/learn/ssr/with-loaders", <LearnSsrWithLoadersPage />),
+                      {
+                        name: "LearnSsrWithLoadersPage",
+                      },
+                    ),
                   }),
                 ],
               }),
@@ -195,39 +211,42 @@ export const routes = [
                 children: [
                   route({
                     path: "/",
-                    component: defer(<LearnRscPage />, {
+                    component: defer(withMeta("/learn/rsc", <LearnRscPage />), {
                       name: "LearnRscPage",
                     }),
                   }),
                   route({
                     path: "/route-features",
-                    component: defer(<LearnRouteDefinitionsPage />, {
-                      name: "LearnRouteDefinitionsPage",
-                    }),
+                    component: defer(
+                      withMeta("/learn/rsc/route-features", <LearnRouteDefinitionsPage />),
+                      {
+                        name: "LearnRouteDefinitionsPage",
+                      },
+                    ),
                   }),
                 ],
               }),
               route({
                 path: "/actions",
-                component: defer(<LearnActionsPage />, {
+                component: defer(withMeta("/learn/actions", <LearnActionsPage />), {
                   name: "LearnActionsPage",
                 }),
               }),
               route({
                 path: "/error-handling",
-                component: defer(<LearnErrorHandlingPage />, {
+                component: defer(withMeta("/learn/error-handling", <LearnErrorHandlingPage />), {
                   name: "LearnErrorHandlingPage",
                 }),
               }),
               route({
                 path: "/transitions",
-                component: defer(<LearnTransitionsPage />, {
+                component: defer(withMeta("/learn/transitions", <LearnTransitionsPage />), {
                   name: "LearnTransitionsPage",
                 }),
               }),
               route({
                 path: "/loaders",
-                component: defer(<LearnLoadersPage />, {
+                component: defer(withMeta("/learn/loaders", <LearnLoadersPage />), {
                   name: "LearnLoadersPage",
                 }),
               }),
@@ -239,31 +258,31 @@ export const routes = [
             children: [
               route({
                 path: "/",
-                component: defer(<ApiReferenceIndexPage />, {
+                component: defer(withMeta("/api", <ApiReferenceIndexPage />), {
                   name: "ApiReferenceIndexPage",
                 }),
               }),
               route({
                 path: "/components",
-                component: defer(<ApiComponentsPage />, {
+                component: defer(withMeta("/api/components", <ApiComponentsPage />), {
                   name: "ApiComponentsPage",
                 }),
               }),
               route({
                 path: "/hooks",
-                component: defer(<ApiHooksPage />, {
+                component: defer(withMeta("/api/hooks", <ApiHooksPage />), {
                   name: "ApiHooksPage",
                 }),
               }),
               route({
                 path: "/utilities",
-                component: defer(<ApiUtilitiesPage />, {
+                component: defer(withMeta("/api/utilities", <ApiUtilitiesPage />), {
                   name: "ApiUtilitiesPage",
                 }),
               }),
               route({
                 path: "/types",
-                component: defer(<ApiTypesPage />, {
+                component: defer(withMeta("/api/types", <ApiTypesPage />), {
                   name: "ApiTypesPage",
                 }),
               }),
@@ -271,15 +290,15 @@ export const routes = [
           }),
           route({
             path: "/examples",
-            component: defer(<ExamplesPage />, { name: "ExamplesPage" }),
+            component: defer(withMeta("/examples", <ExamplesPage />), { name: "ExamplesPage" }),
           }),
           route({
             path: "/faq",
-            component: defer(<FaqPage />, { name: "FaqPage" }),
+            component: defer(withMeta("/faq", <FaqPage />), { name: "FaqPage" }),
           }),
           route({
             path: "/*",
-            component: defer(<NotFoundPage />, { name: "NotFoundPage" }),
+            component: defer(withMeta("/*", <NotFoundPage />), { name: "NotFoundPage" }),
           }),
         ],
       }),

--- a/packages/docs/src/Root.tsx
+++ b/packages/docs/src/Root.tsx
@@ -6,23 +6,15 @@ export default function Root({ children }: { children: ReactNode }) {
       <head>
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>FUNSTACK Router - Documentation</title>
-        <meta name="description" content="Modern React router built on the Navigation API" />
-        <meta property="og:title" content="FUNSTACK Router" />
-        <meta property="og:description" content="Modern React router built on the Navigation API" />
+        {/* Page-specific tags (title, description, canonical, og:title/description/url)
+            are rendered per page by PageMeta and hoisted into <head> by React. */}
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://router.funstack.work/" />
         <meta property="og:site_name" content="FUNSTACK Router" />
         <meta
           property="og:image"
           content="https://router.funstack.work/FUNSTACK_Router_Hero_small.png"
         />
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content="FUNSTACK Router" />
-        <meta
-          name="twitter:description"
-          content="Modern React router built on the Navigation API"
-        />
         <meta
           name="twitter:image"
           content="https://router.funstack.work/FUNSTACK_Router_Hero_small.png"

--- a/packages/docs/src/build.ts
+++ b/packages/docs/src/build.ts
@@ -1,0 +1,22 @@
+/// <reference types="node" />
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { BuildEntryFunction } from "@funstack/static/server";
+import { collectSitePaths } from "./entries.js";
+import { SITE_URL } from "./pageMeta.js";
+
+function generateSitemap(): string {
+  const pagePaths = collectSitePaths().filter((p) => p !== "/*");
+  const urls = pagePaths
+    .map((p) => `  <url><loc>${new URL(p, SITE_URL).href}</loc></url>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+export default (async ({ build, outDir }) => {
+  await Promise.all([build(), writeFile(path.join(outDir, "sitemap.xml"), generateSitemap())]);
+}) satisfies BuildEntryFunction;

--- a/packages/docs/src/components/PageHead.tsx
+++ b/packages/docs/src/components/PageHead.tsx
@@ -1,0 +1,27 @@
+const SITE_NAME = "FUNSTACK Router";
+
+export interface PageHeadProps {
+  /** Page-specific title. Omit for the home page, which uses the site-wide title. */
+  title?: string;
+  description: string;
+}
+
+// Renders a page's title and description metadata. React 19 hoists
+// title/meta tags rendered anywhere in the tree into <head>, both in
+// pre-rendered HTML and on client-side navigation. Colocate this with each
+// page component; URL-related tags (canonical, og:url) are rendered per
+// route in App.tsx via PageMeta.
+export function PageHead({ title, description }: PageHeadProps) {
+  const fullTitle =
+    title === undefined ? `${SITE_NAME} - Documentation` : `${title} | ${SITE_NAME}`;
+  return (
+    <>
+      <title>{fullTitle}</title>
+      <meta name="description" content={description} />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={description} />
+    </>
+  );
+}

--- a/packages/docs/src/entries.tsx
+++ b/packages/docs/src/entries.tsx
@@ -24,6 +24,12 @@ function collectPaths(routeDefs: RouteDefinition[], prefix: string): string[] {
   return paths;
 }
 
+// All page paths of the site (including the "/*" 404 path).
+// Also used by build.ts to generate sitemap.xml.
+export function collectSitePaths(): string[] {
+  return collectPaths(routes, "");
+}
+
 function toEntry(path: string): { ssrPath: string; outputPath: string } {
   if (path === "/*") {
     return { ssrPath: "/__404__", outputPath: "404.html" };
@@ -37,7 +43,7 @@ function toEntry(path: string): { ssrPath: string; outputPath: string } {
 }
 
 export default function getEntries(): EntryDefinition[] {
-  const paths = collectPaths(routes, "");
+  const paths = collectSitePaths();
   return paths.map((path) => {
     const { ssrPath, outputPath } = toEntry(path);
     return {

--- a/packages/docs/src/pageMeta.tsx
+++ b/packages/docs/src/pageMeta.tsx
@@ -1,0 +1,151 @@
+export const SITE_URL = "https://router.funstack.work";
+
+const SITE_NAME = "FUNSTACK Router";
+
+interface PageMetaEntry {
+  /** Page-specific title. Omitted for the home page, which uses the site-wide title. */
+  title?: string;
+  description: string;
+}
+
+// Metadata for every page, keyed by the full route path.
+// The `/*` entry is the 404 page; it gets no canonical URL.
+export const pageMetaMap: Record<string, PageMetaEntry> = {
+  "/": {
+    description:
+      "FUNSTACK Router is a truly modern router for React SPAs, built on the Navigation API and URLPattern instead of the History API, with async React support, type safety, SSR, and RSC.",
+  },
+  "/getting-started": {
+    title: "Getting Started",
+    description:
+      "Install @funstack/router and build your first routes: define a route tree, render the Router component, and navigate with plain anchor tags.",
+  },
+  "/learn": {
+    title: "Learn",
+    description:
+      "Practical, use-case-driven guides for @funstack/router: nested routes, type safety, loaders, actions, transitions, SSR, and React Server Components.",
+  },
+  "/learn/navigation-api": {
+    title: "Navigation API",
+    description:
+      "How FUNSTACK Router builds on the browser's Navigation API instead of the History API, and what that means for interception, transitions, and native anchor navigation.",
+  },
+  "/learn/nested-routes": {
+    title: "Nested Routes",
+    description:
+      "Compose layouts and child routes in FUNSTACK Router with nested route definitions and the Outlet component.",
+  },
+  "/learn/type-safety": {
+    title: "Type Safety",
+    description:
+      "How FUNSTACK Router derives TypeScript types for route params from your path patterns, keeping route components type-safe.",
+  },
+  "/learn/ssr": {
+    title: "Server-Side Rendering",
+    description:
+      "FUNSTACK Router's two-stage SSR model: pathless layout routes render an app shell on the server, while path-based routes and loaders activate after client hydration.",
+  },
+  "/learn/ssr/static-site-generation": {
+    title: "Static Site Generation",
+    description:
+      "Pre-render FUNSTACK Router pages to static HTML at build time, including per-path rendering with the ssrPath option.",
+  },
+  "/learn/ssr/with-loaders": {
+    title: "SSR with Loaders",
+    description:
+      "Run loaders during server-side rendering with FUNSTACK Router to produce fully rendered HTML that includes loader data.",
+  },
+  "/learn/rsc": {
+    title: "React Server Components",
+    description:
+      "Use FUNSTACK Router in React Server Components environments, where route components render on the server and stream to the client.",
+  },
+  "/learn/rsc/route-features": {
+    title: "RSC with Route Features",
+    description:
+      "Combine React Server Components with FUNSTACK Router features like loaders and route params using the server route definition API.",
+  },
+  "/learn/actions": {
+    title: "Form Actions",
+    description:
+      "Intercept form submissions with FUNSTACK Router actions: run client-side logic before navigation while keeping progressive enhancement in mind.",
+  },
+  "/learn/error-handling": {
+    title: "Error Handling",
+    description:
+      "Handle route errors in FUNSTACK Router by placing Error Boundaries around the Outlet in layout routes, keeping shared UI visible when child routes fail.",
+  },
+  "/learn/transitions": {
+    title: "Controlling Transitions",
+    description:
+      "FUNSTACK Router wraps navigations in React's startTransition. Learn how transitions affect rendering and how to control them.",
+  },
+  "/learn/loaders": {
+    title: "Loaders",
+    description:
+      "When FUNSTACK Router loaders execute, how their results are cached, and how different types of navigation affect loader behavior.",
+  },
+  "/api": {
+    title: "API Reference",
+    description:
+      "Complete API reference for @funstack/router: components, hooks, utilities, and TypeScript types.",
+  },
+  "/api/components": {
+    title: "Components API",
+    description: "API reference for FUNSTACK Router components, including Router and Outlet.",
+  },
+  "/api/hooks": {
+    title: "Hooks API",
+    description:
+      "API reference for FUNSTACK Router hooks for accessing route params, navigation state, and programmatic navigation.",
+  },
+  "/api/utilities": {
+    title: "Utilities API",
+    description:
+      "API reference for FUNSTACK Router utility functions, including route definition helpers.",
+  },
+  "/api/types": {
+    title: "Types API",
+    description:
+      "API reference for TypeScript types exported by @funstack/router, including route definitions and matched routes.",
+  },
+  "/examples": {
+    title: "Examples",
+    description:
+      "Code examples for FUNSTACK Router: basic routing, layouts with nested routes, route params, and programmatic navigation.",
+  },
+  "/faq": {
+    title: "FAQ",
+    description:
+      "Frequently asked questions about FUNSTACK Router, including browser support, comparison with other routers, and migration tips.",
+  },
+  "/*": {
+    title: "Page Not Found",
+    description: "The page you were looking for does not exist.",
+  },
+};
+
+// Renders per-page metadata tags. React 19 hoists title/meta/link tags
+// rendered anywhere in the tree into <head>, both in pre-rendered HTML and
+// on client-side navigation.
+export function PageMeta({ path }: { path: string }) {
+  const meta = pageMetaMap[path];
+  if (meta === undefined) {
+    throw new Error(`No page metadata defined for path: ${path}`);
+  }
+  const fullTitle =
+    meta.title === undefined ? `${SITE_NAME} - Documentation` : `${meta.title} | ${SITE_NAME}`;
+  const canonicalUrl = path === "/*" ? undefined : new URL(path, SITE_URL).href;
+  return (
+    <>
+      <title>{fullTitle}</title>
+      <meta name="description" content={meta.description} />
+      {canonicalUrl !== undefined && <link rel="canonical" href={canonicalUrl} />}
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={meta.description} />
+      {canonicalUrl !== undefined && <meta property="og:url" content={canonicalUrl} />}
+      <meta name="twitter:title" content={fullTitle} />
+      <meta name="twitter:description" content={meta.description} />
+    </>
+  );
+}

--- a/packages/docs/src/pageMeta.tsx
+++ b/packages/docs/src/pageMeta.tsx
@@ -1,151 +1,18 @@
 export const SITE_URL = "https://router.funstack.work";
 
-const SITE_NAME = "FUNSTACK Router";
-
-interface PageMetaEntry {
-  /** Page-specific title. Omitted for the home page, which uses the site-wide title. */
-  title?: string;
-  description: string;
-}
-
-// Metadata for every page, keyed by the full route path.
-// The `/*` entry is the 404 page; it gets no canonical URL.
-export const pageMetaMap: Record<string, PageMetaEntry> = {
-  "/": {
-    description:
-      "FUNSTACK Router is a truly modern router for React SPAs, built on the Navigation API and URLPattern instead of the History API, with async React support, type safety, SSR, and RSC.",
-  },
-  "/getting-started": {
-    title: "Getting Started",
-    description:
-      "Install @funstack/router and build your first routes: define a route tree, render the Router component, and navigate with plain anchor tags.",
-  },
-  "/learn": {
-    title: "Learn",
-    description:
-      "Practical, use-case-driven guides for @funstack/router: nested routes, type safety, loaders, actions, transitions, SSR, and React Server Components.",
-  },
-  "/learn/navigation-api": {
-    title: "Navigation API",
-    description:
-      "How FUNSTACK Router builds on the browser's Navigation API instead of the History API, and what that means for interception, transitions, and native anchor navigation.",
-  },
-  "/learn/nested-routes": {
-    title: "Nested Routes",
-    description:
-      "Compose layouts and child routes in FUNSTACK Router with nested route definitions and the Outlet component.",
-  },
-  "/learn/type-safety": {
-    title: "Type Safety",
-    description:
-      "How FUNSTACK Router derives TypeScript types for route params from your path patterns, keeping route components type-safe.",
-  },
-  "/learn/ssr": {
-    title: "Server-Side Rendering",
-    description:
-      "FUNSTACK Router's two-stage SSR model: pathless layout routes render an app shell on the server, while path-based routes and loaders activate after client hydration.",
-  },
-  "/learn/ssr/static-site-generation": {
-    title: "Static Site Generation",
-    description:
-      "Pre-render FUNSTACK Router pages to static HTML at build time, including per-path rendering with the ssrPath option.",
-  },
-  "/learn/ssr/with-loaders": {
-    title: "SSR with Loaders",
-    description:
-      "Run loaders during server-side rendering with FUNSTACK Router to produce fully rendered HTML that includes loader data.",
-  },
-  "/learn/rsc": {
-    title: "React Server Components",
-    description:
-      "Use FUNSTACK Router in React Server Components environments, where route components render on the server and stream to the client.",
-  },
-  "/learn/rsc/route-features": {
-    title: "RSC with Route Features",
-    description:
-      "Combine React Server Components with FUNSTACK Router features like loaders and route params using the server route definition API.",
-  },
-  "/learn/actions": {
-    title: "Form Actions",
-    description:
-      "Intercept form submissions with FUNSTACK Router actions: run client-side logic before navigation while keeping progressive enhancement in mind.",
-  },
-  "/learn/error-handling": {
-    title: "Error Handling",
-    description:
-      "Handle route errors in FUNSTACK Router by placing Error Boundaries around the Outlet in layout routes, keeping shared UI visible when child routes fail.",
-  },
-  "/learn/transitions": {
-    title: "Controlling Transitions",
-    description:
-      "FUNSTACK Router wraps navigations in React's startTransition. Learn how transitions affect rendering and how to control them.",
-  },
-  "/learn/loaders": {
-    title: "Loaders",
-    description:
-      "When FUNSTACK Router loaders execute, how their results are cached, and how different types of navigation affect loader behavior.",
-  },
-  "/api": {
-    title: "API Reference",
-    description:
-      "Complete API reference for @funstack/router: components, hooks, utilities, and TypeScript types.",
-  },
-  "/api/components": {
-    title: "Components API",
-    description: "API reference for FUNSTACK Router components, including Router and Outlet.",
-  },
-  "/api/hooks": {
-    title: "Hooks API",
-    description:
-      "API reference for FUNSTACK Router hooks for accessing route params, navigation state, and programmatic navigation.",
-  },
-  "/api/utilities": {
-    title: "Utilities API",
-    description:
-      "API reference for FUNSTACK Router utility functions, including route definition helpers.",
-  },
-  "/api/types": {
-    title: "Types API",
-    description:
-      "API reference for TypeScript types exported by @funstack/router, including route definitions and matched routes.",
-  },
-  "/examples": {
-    title: "Examples",
-    description:
-      "Code examples for FUNSTACK Router: basic routing, layouts with nested routes, route params, and programmatic navigation.",
-  },
-  "/faq": {
-    title: "FAQ",
-    description:
-      "Frequently asked questions about FUNSTACK Router, including browser support, comparison with other routers, and migration tips.",
-  },
-  "/*": {
-    title: "Page Not Found",
-    description: "The page you were looking for does not exist.",
-  },
-};
-
-// Renders per-page metadata tags. React 19 hoists title/meta/link tags
-// rendered anywhere in the tree into <head>, both in pre-rendered HTML and
-// on client-side navigation.
+// Renders URL-related metadata for a page, derived from its route path.
+// Title and description tags are colocated with each page component via
+// PageHead instead.
 export function PageMeta({ path }: { path: string }) {
-  const meta = pageMetaMap[path];
-  if (meta === undefined) {
-    throw new Error(`No page metadata defined for path: ${path}`);
+  if (path === "/*") {
+    // The 404 page has no canonical URL.
+    return null;
   }
-  const fullTitle =
-    meta.title === undefined ? `${SITE_NAME} - Documentation` : `${meta.title} | ${SITE_NAME}`;
-  const canonicalUrl = path === "/*" ? undefined : new URL(path, SITE_URL).href;
+  const canonicalUrl = new URL(path, SITE_URL).href;
   return (
     <>
-      <title>{fullTitle}</title>
-      <meta name="description" content={meta.description} />
-      {canonicalUrl !== undefined && <link rel="canonical" href={canonicalUrl} />}
-      <meta property="og:title" content={fullTitle} />
-      <meta property="og:description" content={meta.description} />
-      {canonicalUrl !== undefined && <meta property="og:url" content={canonicalUrl} />}
-      <meta name="twitter:title" content={fullTitle} />
-      <meta name="twitter:description" content={meta.description} />
+      <link rel="canonical" href={canonicalUrl} />
+      <meta property="og:url" content={canonicalUrl} />
     </>
   );
 }

--- a/packages/docs/src/pages/ApiComponentsPage.tsx
+++ b/packages/docs/src/pages/ApiComponentsPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function ApiComponentsPage() {
   return (
     <div className="page docs-page api-page">
+      <PageHead
+        title="Components API"
+        description="API reference for FUNSTACK Router components, including Router and Outlet."
+      />
       <h1>Components</h1>
       <p className="page-intro">Core components for building routing in your React application.</p>
 

--- a/packages/docs/src/pages/ApiHooksPage.tsx
+++ b/packages/docs/src/pages/ApiHooksPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function ApiHooksPage() {
   return (
     <div className="page docs-page api-page">
+      <PageHead
+        title="Hooks API"
+        description="API reference for FUNSTACK Router hooks for accessing route params, navigation state, and programmatic navigation."
+      />
       <h1>Hooks</h1>
       <p className="page-intro">React hooks for accessing router state and navigation.</p>
 

--- a/packages/docs/src/pages/ApiReferenceIndexPage.tsx
+++ b/packages/docs/src/pages/ApiReferenceIndexPage.tsx
@@ -1,6 +1,12 @@
+import { PageHead } from "../components/PageHead.js";
+
 export function ApiReferenceIndexPage() {
   return (
     <div className="api-overview">
+      <PageHead
+        title="API Reference"
+        description="Complete API reference for @funstack/router: components, hooks, utilities, and TypeScript types."
+      />
       <p>
         Complete API documentation for <code>@funstack/router</code>. Select a category above or
         browse below.

--- a/packages/docs/src/pages/ApiTypesPage.tsx
+++ b/packages/docs/src/pages/ApiTypesPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function ApiTypesPage() {
   return (
     <div className="page docs-page api-page">
+      <PageHead
+        title="Types API"
+        description="API reference for TypeScript types exported by @funstack/router, including route definitions and matched routes."
+      />
       <h1>Types</h1>
       <p className="page-intro">TypeScript types and interfaces exported by the router.</p>
 

--- a/packages/docs/src/pages/ApiUtilitiesPage.tsx
+++ b/packages/docs/src/pages/ApiUtilitiesPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function ApiUtilitiesPage() {
   return (
     <div className="page docs-page api-page">
+      <PageHead
+        title="Utilities API"
+        description="API reference for FUNSTACK Router utility functions, including route definition helpers."
+      />
       <h1>Utilities</h1>
       <p className="page-intro">Helper functions for defining routes and managing state.</p>
 

--- a/packages/docs/src/pages/ExamplesPage.tsx
+++ b/packages/docs/src/pages/ExamplesPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function ExamplesPage() {
   return (
     <div className="page docs-page">
+      <PageHead
+        title="Examples"
+        description="Code examples for FUNSTACK Router: basic routing, layouts with nested routes, route params, and programmatic navigation."
+      />
       <h1>Examples</h1>
 
       <section>

--- a/packages/docs/src/pages/FaqPage.tsx
+++ b/packages/docs/src/pages/FaqPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function FaqPage() {
   return (
     <div className="page docs-page">
+      <PageHead
+        title="FAQ"
+        description="Frequently asked questions about FUNSTACK Router, including browser support, comparison with other routers, and migration tips."
+      />
       <h1>FAQ</h1>
 
       <section>

--- a/packages/docs/src/pages/GettingStartedPage.tsx
+++ b/packages/docs/src/pages/GettingStartedPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function GettingStartedPage() {
   return (
     <div className="page docs-page">
+      <PageHead
+        title="Getting Started"
+        description="Install @funstack/router and build your first routes: define a route tree, render the Router component, and navigate with plain anchor tags."
+      />
       <h1>Getting Started</h1>
 
       <section>

--- a/packages/docs/src/pages/HomePage.tsx
+++ b/packages/docs/src/pages/HomePage.tsx
@@ -1,8 +1,10 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function HomePage() {
   return (
     <div className="page home-page">
+      <PageHead description="FUNSTACK Router is a truly modern router for React SPAs, built on the Navigation API and URLPattern instead of the History API, with async React support, type safety, SSR, and RSC." />
       <section className="hero">
         <h1>FUNSTACK Router</h1>
         <p className="tagline">

--- a/packages/docs/src/pages/LearnActionsPage.tsx
+++ b/packages/docs/src/pages/LearnActionsPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnActionsPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Form Actions"
+        description="Intercept form submissions with FUNSTACK Router actions: run client-side logic before navigation while keeping progressive enhancement in mind."
+      />
       <h2>Form Actions</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnErrorHandlingPage.tsx
+++ b/packages/docs/src/pages/LearnErrorHandlingPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnErrorHandlingPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Error Handling"
+        description="Handle route errors in FUNSTACK Router by placing Error Boundaries around the Outlet in layout routes, keeping shared UI visible when child routes fail."
+      />
       <h2>Error Handling</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnIndexPage.tsx
+++ b/packages/docs/src/pages/LearnIndexPage.tsx
@@ -1,6 +1,12 @@
+import { PageHead } from "../components/PageHead.js";
+
 export function LearnIndexPage() {
   return (
     <div className="learn-overview">
+      <PageHead
+        title="Learn"
+        description="Practical, use-case-driven guides for @funstack/router: nested routes, type safety, loaders, actions, transitions, SSR, and React Server Components."
+      />
       <p className="page-intro">
         These guides teach you how to use <code>@funstack/router</code> through practical,
         use-case-driven examples.

--- a/packages/docs/src/pages/LearnLoadersPage.tsx
+++ b/packages/docs/src/pages/LearnLoadersPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnLoadersPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Loaders"
+        description="When FUNSTACK Router loaders execute, how their results are cached, and how different types of navigation affect loader behavior."
+      />
       <h2>How Loaders Run</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnNavigationApiPage.tsx
+++ b/packages/docs/src/pages/LearnNavigationApiPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnNavigationApiPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Navigation API"
+        description="How FUNSTACK Router builds on the browser's Navigation API instead of the History API, and what that means for interception, transitions, and native anchor navigation."
+      />
       <h2>Navigation API</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnNestedRoutesPage.tsx
+++ b/packages/docs/src/pages/LearnNestedRoutesPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnNestedRoutesPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Nested Routes"
+        description="Compose layouts and child routes in FUNSTACK Router with nested route definitions and the Outlet component."
+      />
       <h2>Nested Routes</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnRouteDefinitionsPage.tsx
+++ b/packages/docs/src/pages/LearnRouteDefinitionsPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnRouteDefinitionsPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="RSC with Route Features"
+        description="Combine React Server Components with FUNSTACK Router features like loaders and route params using the server route definition API."
+      />
       <h2>RSC with Route Features</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnRscPage.tsx
+++ b/packages/docs/src/pages/LearnRscPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnRscPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="React Server Components"
+        description="Use FUNSTACK Router in React Server Components environments, where route components render on the server and stream to the client."
+      />
       <h2>React Server Components</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnSsgPage.tsx
+++ b/packages/docs/src/pages/LearnSsgPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnSsgPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Static Site Generation"
+        description="Pre-render FUNSTACK Router pages to static HTML at build time, including per-path rendering with the ssrPath option."
+      />
       <h2>Static Site Generation</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnSsrBasicPage.tsx
+++ b/packages/docs/src/pages/LearnSsrBasicPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnSsrBasicPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Server-Side Rendering"
+        description="FUNSTACK Router's two-stage SSR model: pathless layout routes render an app shell on the server, while path-based routes and loaders activate after client hydration."
+      />
       <h2>How SSR Works</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnSsrWithLoadersPage.tsx
+++ b/packages/docs/src/pages/LearnSsrWithLoadersPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnSsrWithLoadersPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="SSR with Loaders"
+        description="Run loaders during server-side rendering with FUNSTACK Router to produce fully rendered HTML that includes loader data."
+      />
       <h2>SSR with Loaders</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnTransitionsPage.tsx
+++ b/packages/docs/src/pages/LearnTransitionsPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnTransitionsPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Controlling Transitions"
+        description="FUNSTACK Router wraps navigations in React's startTransition. Learn how transitions affect rendering and how to control them."
+      />
       <h2>Controlling Transitions</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/LearnTypeSafetyPage.tsx
+++ b/packages/docs/src/pages/LearnTypeSafetyPage.tsx
@@ -1,8 +1,13 @@
 import { CodeBlock } from "../components/CodeBlock.js";
+import { PageHead } from "../components/PageHead.js";
 
 export function LearnTypeSafetyPage() {
   return (
     <div className="learn-content">
+      <PageHead
+        title="Type Safety"
+        description="How FUNSTACK Router derives TypeScript types for route params from your path patterns, keeping route components type-safe."
+      />
       <h2>Type Safety</h2>
 
       <p className="page-intro">

--- a/packages/docs/src/pages/NotFoundPage.tsx
+++ b/packages/docs/src/pages/NotFoundPage.tsx
@@ -1,6 +1,12 @@
+import { PageHead } from "../components/PageHead.js";
+
 export function NotFoundPage() {
   return (
     <div className="page not-found-page">
+      <PageHead
+        title="Page Not Found"
+        description="The page you were looking for does not exist."
+      />
       <h1>Page Not Found</h1>
       <p>The page you're looking for doesn't exist.</p>
       <p>

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [
     funstackStatic({
       entries: "./src/entries.tsx",
+      build: "./src/build.ts",
       ssr: true,
     }),
     react(),

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -7,6 +7,7 @@
     "react",
     "router"
   ],
+  "homepage": "https://router.funstack.work/",
   "license": "MIT",
   "author": "uhyo <uhyo@uhy.ooo>",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/node':
+        specifier: ^26.2.0
+        version: 26.2.0
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18


### PR DESCRIPTION
## Summary

The docs site at https://router.funstack.work/ is stuck at "Discovered – currently not indexed" in Google Search Console. This PR addresses the on-site causes:

- **Per-page metadata**: every page previously shared the identical `<title>`, meta description, and `og:url` from the HTML shell, making all pages look like duplicates to search engines. Now:
  - Each page component renders a `PageHead` component (`packages/docs/src/components/PageHead.tsx`) with its own title and description, colocated with the page content; React 19 hoists the tags into `<head>` both in pre-rendered HTML and on client-side navigation.
  - URL-derived tags (canonical URL and `og:url`) are rendered per route by `PageMeta` (`packages/docs/src/pageMeta.tsx`), wired into the route definitions in `App.tsx` via a small `withMeta(path, node)` helper.
  - `Root.tsx` now only carries site-wide tags (charset, viewport, `og:type`/`og:site_name`/`og:image`, twitter card/image).
- **Sitemap**: a custom build entry (`packages/docs/src/build.ts`, wired via the `build` option of `funstackStatic()`) generates `sitemap.xml` at build time from the same route list `entries.tsx` uses, so new pages are included automatically. The `/*` 404 route is excluded.
- **robots.txt**: added to `packages/docs/public/`, referencing the sitemap.
- **npm linkage**: added `"homepage"` to `packages/router/package.json` so the npm page links to the docs site.

The 404 page gets a "Page Not Found" title and no canonical URL.

## Verification

Built with Node 24 and inspected `dist/public`: each page has its unique title (e.g. `Loaders | FUNSTACK Router`), description, canonical, and og tags hoisted into `<head>` with no duplicates or stray tags in `<body>`; `sitemap.xml` lists all 22 pages. `typecheck`, `lint`, `format:check`, and `test:run` all pass. `@types/node` was added as a docs devDependency for `build.ts`.

## After deploy

Submit `https://router.funstack.work/sitemap.xml` in Google Search Console and re-request indexing of the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A87oZm2DQbbUV5iWNCKDR9